### PR TITLE
Bring compatibility with JAX v0.9.x

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           # Mandatory dependencies.
-          python -m pip install flax 'jax<0.4.36' numpy
+          python -m pip install flax==0.12.6 jax==0.9.0 numpy
           # Testing dependencies.
           python -m pip install \
             mypy pytest pytest-cov pytest-dirty pytest-timeout transformers

--- a/.github/workflows/on-schedule.yml
+++ b/.github/workflows/on-schedule.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           # Mandatory dependencies.
-          python -m pip install flax 'jax<0.4.36' numpy
+          python -m pip install flax==0.12.6 jax==0.9.0 numpy
           # Testing dependencies.
           python -m pip install \
             mypy pytest pytest-cov pytest-dirty pytest-timeout transformers

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ functions with GELU or substitute all `nn.Dense` layers with LoRA adapters.
 ```python
 # Replace ReLU with GELU
 gelu_mox = yax.make_mox(nn.gelu)(inputs)
-modified_mox = yax.sub('//pjit[@name="relu"]', gelu_mox, mox)
+modified_mox = yax.sub('//jit[@name="relu"]', gelu_mox, mox)
 
 # Apply LoRA-adapters to all fully-connected layers.
 lora_mox = yax.make_mox(lora.apply)(params, inputs)
@@ -135,12 +135,12 @@ XML is actually a good and even appropriate serialization format.
     <input type="fp32[10]">c</input>
     <output type="fp32[10,10]">d</output>
   </dot_general>
-  <pjit
+  <jit
     jaxpr="{ lambda ; a:f32[10], b:f32[10]. let c:f32[10] = add a b in (c,) }">
     <input type="fp32[10]">d</input>
     <input type="fp32[10]">a</input>
     <output type="fp32[10]">e</output>
-  </pjit>
+  </jit>
   <outputs type="fp32[10]">e</outputs>
 </module_call>
 ```
@@ -161,7 +161,7 @@ XML.
    dimension_numbers="[[[0], [0]], [[], []]]";
    inputs={с="fp32[10]"; b="fp32[10,10]};
    outputs={d="fp32[10]"}>#;
-  <primitive="pjit";
+  <primitive="jit";
    inputs={d="fp32[10]"; a="fp32[10]"};
    outputs={e="fp32[10]"};
    jaxpr="{ lambda ; a:f32[10], b:f32[10]. let c:f32[10] = add a b in (c,) }";

--- a/examples/lora/lora.py
+++ b/examples/lora/lora.py
@@ -24,6 +24,7 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 from flax.linen.initializers import lecun_normal, zeros_init
+from flax.linen.linear import PromoteDtypeFn, promote_dtype
 from flax.typing import Dtype, Initializer, PrecisionLike
 from jax.tree_util import DictKey, tree_map_with_path
 
@@ -65,6 +66,7 @@ class LoRA(nn.Module):
     precision: PrecisionLike = None
     kernel_init: Initializer = lecun_normal()
     bias_init: Initializer = zeros_init()
+    promote_dtype: PromoteDtypeFn = promote_dtype
 
     @nn.compact
     def __call__(self, xs):
@@ -77,8 +79,9 @@ class LoRA(nn.Module):
         rhs = self.param('rhs', self.rhs_init, rhs_shape, self.param_dtype)
 
         kwargs = dict(use_bias=self.use_bias, dtype=self.dtype,
-                      param_dtype=self.dtype, precision=self.precision,
-                      kernel_init=self.kernel_init, bias_init=self.bias_init)
+                      param_dtype=self.param_dtype, precision=self.precision,
+                      kernel_init=self.kernel_init, bias_init=self.bias_init,
+                      promote_dtype=self.promote_dtype)
         if self.original_name:
             kwargs['name'] = self.original_name
 

--- a/examples/lora/lora_test.py
+++ b/examples/lora/lora_test.py
@@ -5,7 +5,6 @@ import jax
 import jax.numpy as jnp
 import pytest
 from numpy.testing import assert_allclose
-from transformers import FlaxRobertaForSequenceClassification as RoBERTa
 
 from lora import Params, lora, mask_by_prefix, merge, split
 from yax import eval_mox, make_mox, query
@@ -53,8 +52,8 @@ def test_simple():
 
     # 4. Merge LoRA-adapter to original fully-connected layer.
     merged_params = merge(lora_params)
-    flat_merged_params, merged_tree = jax.tree_flatten(merged_params)
-    flat_params, tree = jax.tree_flatten(params)
+    flat_merged_params, merged_tree = jax.tree.flatten(merged_params)
+    flat_params, tree = jax.tree.flatten(params)
     assert merged_tree == tree
     for actual, desired in zip(flat_merged_params, flat_params):
         assert_allclose(actual, desired)
@@ -63,6 +62,9 @@ def test_simple():
 
 @pytest.mark.slow
 def test_roberta():
+    transformers = pytest.importorskip('transformers')
+    RoBERTa = transformers.FlaxRobertaForSequenceClassification
+
     # 0. Load model and create application function (HuggingFace stores weights
     #    as a part of the model).
     model = RoBERTa.from_pretrained('roberta-base')
@@ -103,8 +105,8 @@ def test_roberta():
 
     # 4. Merge LoRA-adapter to original fully-connected layer.
     params_merged = merge(params_lora)
-    flat_params_merged, merged_tree = jax.tree_flatten(params_merged)
-    flat_params, tree = jax.tree_flatten(params)
+    flat_params_merged, merged_tree = jax.tree.flatten(params_merged)
+    flat_params, tree = jax.tree.flatten(params)
     assert merged_tree == tree
     for actual, desired in zip(flat_params_merged, flat_params):
         assert_allclose(actual, desired)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Typing :: Typed",
 ]
-dependencies = ["flax", "jax<0.4.36", "numpy"]
+dependencies = ["flax>=0.12.6", "jax>=0.9.0", "numpy"]
 requires-python = ">=3.12,<4"
 
 [project.optional-dependencies]

--- a/tests/dynamic_test.py
+++ b/tests/dynamic_test.py
@@ -18,7 +18,7 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import pytest
-from jax.core import ConcreteArray, ShapedArray
+from jax.core import AbstractValue, ShapedArray
 from numpy.testing import assert_allclose
 
 from yax import Literal, Mox, Symbol, Var, eval_mox, make_mox
@@ -44,7 +44,8 @@ def assert_output_types(mox: Mox, types: Type[Symbol]):
     for output, type_ in zip(mox.outputs, types):
         assert isinstance(output, type_)
         if type_ is Literal:
-            assert isinstance(output.value, ConcreteArray)
+            assert not isinstance(output.value, AbstractValue)
+            assert isinstance(output.aval, ShapedArray)
         elif type_ is Var:
             assert isinstance(output.value, ShapedArray)
         else:
@@ -91,6 +92,20 @@ def test_pure_mixed():
     assert len(actual) == 2
     assert_allclose(actual[0], value)
     assert_allclose(actual[1], const)
+
+
+def test_mixed_literal_input():
+    def fn(xs) -> jax.Array:
+        return xs > 0
+
+    value = jnp.array([-1, 1])
+    mox = make_mox(fn)(value)
+
+    assert any(
+        isinstance(sym, Literal)
+        for child in mox.children
+        for sym in child.inputs)
+    assert_allclose(eval_mox(mox, value), fn(value))
 
 
 class InputLiteralModel(nn.Module):

--- a/tests/query_test.py
+++ b/tests/query_test.py
@@ -24,9 +24,9 @@ from yax import Equation, Expr, Mox, XPath, make_mox, query, tokenize_xpath
 with_xpaths = pytest.mark.parametrize('value', [
     '/',
     '//',
-    '//pjit',
+    '//jit',
     '//[@primitive="module_call"]',
-    '//[@primitive="pjit"][@name="relu"]',
+    '//[@primitive="jit"][@name="relu"]',
     '//[@name="Dense_0"][@features=10]',
     '//[@name="ResBlock"]//[@features=10]',
     './module_call/..//[@type="Dense"][@features=10]',
@@ -86,7 +86,7 @@ class TestQuery:
         assert nodes[0] is mox
 
     @pytest.mark.parametrize('value,type_', [
-        pytest.param('//pjit', Equation, id='jaxpr'),
+        pytest.param('//jit', Equation, id='jaxpr'),
         pytest.param('//module_call', Mox, id='mox'),
     ])
     def test_query_by_name(self, mox: Mox, value: str, type_: Type[Expr]):

--- a/tests/static_test.py
+++ b/tests/static_test.py
@@ -1,0 +1,56 @@
+# Copyright 2026 Daniel Bershatsky
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+import pytest
+from numpy.testing import assert_allclose
+
+from yax import eval_mox, make_mox
+
+
+class DropoutModule(nn.Module):
+
+    @nn.compact
+    def __call__(self, xs, train: bool = True):
+        return nn.Dropout(0.5)(xs, deterministic=not train)
+
+
+@pytest.mark.parametrize('kwargs', [{}, {'train': True}])
+def test_static_bool_kwargs(kwargs):
+    xs = jnp.ones((2, 3))
+    rngs = {
+        'params': jax.random.key(0),
+        'dropout': jax.random.key(1),
+    }
+    model = DropoutModule()
+    params = model.init(rngs, xs, **kwargs)
+    apply_rngs = {'dropout': jax.random.key(2)}
+
+    mox = make_mox(model.apply)(params, xs, rngs=apply_rngs, **kwargs)
+
+    actual = eval_mox(mox, params, xs, rngs=apply_rngs, **kwargs)
+    desired = model.apply(params, xs, rngs=apply_rngs, **kwargs)
+    assert_allclose(actual, desired)
+
+
+def test_numeric_scalar_inputs_stay_dynamic():
+    def fn(xs, scale: float):
+        return xs * scale
+
+    xs = jnp.ones((2, 3))
+    mox = make_mox(fn)(xs, 2.0)
+
+    assert_allclose(eval_mox(mox, xs, 3.0), fn(xs, 3.0))

--- a/tests/sub_test.py
+++ b/tests/sub_test.py
@@ -128,7 +128,7 @@ def dummy():
 
 def test_update_in_trees(dummy: Mox):
     """Test substitution with new `Equation`."""
-    relu_expr, *_ = query('//[@primitive="pjit"][@name="relu"]', dummy)
+    relu_expr, *_ = query('//[@primitive="jit"][@name="relu"]', dummy)
     assert isinstance(relu_expr, Equation), 'Equation for relu is expected.'
 
     def act(xs, ys):
@@ -228,7 +228,7 @@ def test_update_var_trees(dummy: Mox):
     # Verify consistency of the root node.
     root, *_ = parents
     (lhs_params, *_), _ = root.in_tree.unflatten(root.inputs)
-    syms, var_tree = jax.tree_flatten(params)
+    syms, var_tree = jax.tree.flatten(params)
     assert var_tree != var_trees[0], 'Params tree must differs.'
 
     args_tree, _ = in_trees[0].children()
@@ -250,7 +250,7 @@ def test_sub_callable(mlp: ModelState):
         assert isinstance(gelu_expr, Equation)
         return gelu_expr
 
-    mox = sub('//[@primitive="pjit"][@name="relu"]', sub_fn, mlp.mox)
+    mox = sub('//[@primitive="jit"][@name="relu"]', sub_fn, mlp.mox)
     actual = eval_mox(mox, mlp.params, mlp.batch)
     desired = mlp.model.apply(mlp.params, mlp.batch)
     assert_allclose(actual, desired)
@@ -262,7 +262,7 @@ class TestSub:
         gelu_mox = make_mox(jax.jit(jax.nn.gelu))(mlp.batch)
         gelu_expr = gelu_mox.children[0]
         assert isinstance(gelu_expr, Equation)
-        mox = sub('//[@primitive="pjit"][@name="relu"]', gelu_expr, mlp.mox)
+        mox = sub('//[@primitive="jit"][@name="relu"]', gelu_expr, mlp.mox)
 
         actual = eval_mox(mox, mlp.params, mlp.batch)
         desired = mlp.model.apply(mlp.params, mlp.batch)

--- a/tests/yax_test.py
+++ b/tests/yax_test.py
@@ -48,7 +48,7 @@ class TestBinaryFunc:
         eq: Equation = mtree.children[0]
         assert len(eq.inputs) == 2
         assert len(eq.outputs) == 1
-        assert eq.prim.name == 'pjit'
+        assert eq.prim.name == 'jit'
 
         assert 'jaxpr' in eq.params
         jaxpr: ClosedJaxpr = eq.params['jaxpr']

--- a/yax.py
+++ b/yax.py
@@ -34,6 +34,7 @@ import jax
 import jax.extend as jex
 import jax.extend.linear_util as lu
 import jax.numpy as jnp
+import numpy as np
 from flax.core.scope import LazyRng
 from flax.linen.module import Callable, InterceptorContext, intercept_methods
 from flax.typing import RNGSequences
@@ -178,17 +179,30 @@ class ModuleTrace(Trace[ModuleTracer]):
             return fun.call_wrapped(*tracers)
 
 
+def _is_static_input(val) -> bool:
+    return (
+        not isinstance(val, AbstractValue | Tracer)
+        and isinstance(val, bool | np.bool_)
+    )
+
+
 @lu.transformation
 def _trace(builder: 'MoxBuilder', *ins):
     trace = ModuleTrace(builder=builder)
 
     with set_current_trace(trace, True):
         # NOTE We manually abstractify up to ShapedArray all input arguments.
-        in_tracers = [
-            trace.pure(jax.api_util.shaped_abstractify(x)) for x in ins
-        ]
+        in_tracers, call_args = [], []
+        for x in ins:
+            if _is_static_input(x):
+                in_tracers.append(trace.literal(x))
+                call_args.append(x)
+            else:
+                in_tracers.append(
+                    trace.pure(jax.api_util.shaped_abstractify(x)))
+                call_args.append(in_tracers[-1])
         builder.set_inputs(in_tracers)
-        outs = yield in_tracers, {}
+        outs = yield call_args, {}
 
         # TODO(@daskol): We do not use output tracers. Should we remove them?
         # This issue is related to the proper implementation of (sub)lifting
@@ -417,14 +431,18 @@ class MoxBuilder:
         args = (context.module, ) + args
         (scope, *in_args), child.in_tree = jax.tree.flatten((args, kwargs))
         trace = find_top_trace(flat_vars + in_args)  # TODO(@daskol): Dynamic!
-        in_tracers = [trace.full_raise(a) for a in in_args]
+        in_tracers, call_args = [], []
+        for arg in in_args:
+            tracer = trace.full_raise(arg)
+            in_tracers.append(tracer)
+            call_args.append(arg if _is_static_input(arg) else tracer)
         child.inputs.extend(self.to_symbols(in_tracers))  # XXX
 
         # Flatten function (inputs and outputs) for building intermediate
         # representation.
         wrap_fn = lu.wrap_init(unbound_fn)
         flat_fn, out_tree_fn = jax.api_util.flatten_fun(wrap_fn, child.in_tree)
-        outs = flat_fn.call_wrapped(scope, *in_tracers)
+        outs = flat_fn.call_wrapped(scope, *call_args)
 
         # TODO(@daskol): Remove code duplication with `_lower`.
         flat_outs, _ = jax.tree.flatten(outs)

--- a/yax.py
+++ b/yax.py
@@ -37,9 +37,9 @@ import jax.numpy as jnp
 from flax.core.scope import LazyRng
 from flax.linen.module import Callable, InterceptorContext, intercept_methods
 from flax.typing import RNGSequences
-from jax.core import (
-    AbstractValue, ClosedJaxpr as Jaxpr, ConcreteArray, MainTrace, ShapedArray,
-    Sublevel, Trace, Tracer, find_top_trace, new_main)
+from jax._src.core import set_current_trace  # noqa: PLC2701
+from jax.core import AbstractValue, ShapedArray, Trace, Tracer, find_top_trace
+from jax.extend.core import ClosedJaxpr as Jaxpr
 
 # TODO(@daskol): Make PR on reexporting PyTreeDef.
 try:
@@ -75,12 +75,14 @@ class ModuleTracer(Tracer):
         # cases when we should preserve original concrete values. For example,
         # arguments of binary operation between tracer and numerical literal
         # like `x > 0`. In this case `x` should be evaluated as `ShapedArray`
-        # and zero as `ConcreteArray`. Otherwise, this constant values get
-        # missing in evaluation time.
+        # and zero as a literal. Otherwise, this constant values get missing
+        # in evaluation time.
         if isinstance(self.value, AbstractValue):
             return self.value
+        elif isinstance(self.value, Tracer):
+            return self.value.aval
         else:
-            return jax.api_util.shaped_abstractify(self.value)
+            return jax.typeof(self.value)
 
     def full_lower(self):
         # TODO(@daskol): How to properly implement lowering?
@@ -103,9 +105,8 @@ class ModuleTracer(Tracer):
 
 class ModuleTrace(Trace[ModuleTracer]):
 
-    def __init__(self, main: MainTrace, sublevel: Sublevel, *,
-                 builder: 'MoxBuilder', **kwargs) -> None:
-        super().__init__(main, sublevel)
+    def __init__(self, *, builder: 'MoxBuilder', **kwargs) -> None:
+        super().__init__()
         self.builder: MoxBuilder = builder
 
     def pure(self, val) -> ModuleTracer:
@@ -119,8 +120,12 @@ class ModuleTrace(Trace[ModuleTracer]):
         if isinstance(val, AbstractValue):
             aval = val
         else:
-            aval = jax.core.get_aval(val)
+            aval = jax.typeof(val)
         return ModuleTracer(self, aval)
+
+    def literal(self, val) -> ModuleTracer:
+        """Wrap a concrete value so it is preserved as a MoX literal."""
+        return ModuleTracer(self, val)
 
     def lift(self, tracer: Tracer) -> ModuleTracer:
         return ModuleTracer(self, tracer)
@@ -128,11 +133,21 @@ class ModuleTrace(Trace[ModuleTracer]):
     def sublift(self, tracer: Tracer) -> ModuleTracer:
         return ModuleTracer(self, tracer)
 
+    def full_raise(self, val) -> ModuleTracer:
+        if isinstance(val, ModuleTracer):
+            if val._trace is self:
+                return val
+            return ModuleTracer(self, val)
+        if isinstance(val, Tracer):
+            return ModuleTracer(self, val)
+        return self.literal(val)
+
     def process_primitive(self, prim: jex.core.Primitive, tracers, params):
+        tracers = [self.full_raise(x) for x in tracers]
         result, _ = prim.abstract_eval(*[x.aval for x in tracers], **params)
 
         outs, out_tree = jax.tree.flatten(result)
-        assert all(isinstance(x, ShapedArray) for x in outs if x), \
+        assert all(isinstance(x, AbstractValue) for x in outs if x), \
             'Assumption on type of result is violated: {outs}.'
 
         out_flat_tracers = [ModuleTracer(self, x) for x in outs]
@@ -158,39 +173,36 @@ class ModuleTrace(Trace[ModuleTracer]):
         #       in_tracers = [trace.sublift(t) for t in tracers]
         #       out_tracers = fun.call_wrapped(*in_tracers)
         #       return [trace.full_raise(t) for t in out_tracers]
-        return fun.call_wrapped(*tracers)
+        tracers = [self.full_raise(x) for x in tracers]
+        with set_current_trace(self):
+            return fun.call_wrapped(*tracers)
 
 
 @lu.transformation
-def _lower(builder: 'MoxBuilder', main: MainTrace, *ins):
-    trace: ModuleTrace = main.with_cur_sublevel()
+def _trace(builder: 'MoxBuilder', *ins):
+    trace = ModuleTrace(builder=builder)
 
-    # NOTE We manually abstractify up to ShapedArray all input arguments.
-    in_tracers = [trace.pure(jax.api_util.shaped_abstractify(x)) for x in ins]
-    builder.set_inputs(in_tracers)
-    outs = yield in_tracers, {}
+    with set_current_trace(trace, True):
+        # NOTE We manually abstractify up to ShapedArray all input arguments.
+        in_tracers = [
+            trace.pure(jax.api_util.shaped_abstractify(x)) for x in ins
+        ]
+        builder.set_inputs(in_tracers)
+        outs = yield in_tracers, {}
 
-    # TODO(@daskol): We do not use output tracers. Should we remove them? This
-    # issue is related to the proper implementation of (sub)lifting and
-    # unboxing that still have quite vague semantics.
-    out_tracers = [trace.full_raise(t) for t in outs]
-    builder.set_outputs(out_tracers)
-    yield out_tracers
-
-
-@lu.transformation
-def _raise(builder, *ins):
-    with new_main(ModuleTrace, True, builder=builder) as main:
-        outs = yield (main, *ins), {}
-        del main
-    yield outs
+        # TODO(@daskol): We do not use output tracers. Should we remove them?
+        # This issue is related to the proper implementation of (sub)lifting
+        # and unboxing that still have quite vague semantics.
+        out_tracers = [trace.full_raise(t) for t in outs]
+        builder.set_outputs(out_tracers)
+        yield out_tracers
 
 
 def trace_modules(wf: lu.WrappedFun, builder: 'MoxBuilder') -> lu.WrappedFun:
-    return _raise(_lower(wf, builder), builder)
+    return _trace(wf, builder)
 
 
-SymbolValueType = TypeVar('SymbolValueType', bound='ShapedArray')
+SymbolValueType = TypeVar('SymbolValueType')
 
 
 @dataclass(slots=True)
@@ -208,6 +220,12 @@ class Symbol(Generic[SymbolValueType]):
     def __hash__(self) -> int:
         return id(self)
 
+    @property
+    def aval(self) -> AbstractValue:
+        if isinstance(self.value, AbstractValue):
+            return self.value
+        return jax.typeof(self.value)
+
 
 @dataclass(slots=True, eq=False)
 class Var(Symbol[ShapedArray]):
@@ -215,17 +233,19 @@ class Var(Symbol[ShapedArray]):
 
 
 @dataclass(slots=True, eq=False)
-class Literal(Symbol[ConcreteArray]):
+class Literal(Symbol[Any]):
+    aval: AbstractValue
+
     @property
     def const(self):
-        return self.value.val
+        return self.value
 
 
 # Check hashability of Symbol hierarchy.
 _ = {
     Symbol(ShapedArray((), jnp.float32)),
     Var(ShapedArray((), jnp.float32)),
-    Literal(ConcreteArray(jnp.float32, jnp.empty(()))),
+    Literal(jnp.empty(()), ShapedArray((), jnp.float32)),
 }
 
 
@@ -447,14 +467,13 @@ class MoxBuilder:
         symbols = []
         for tracer in tracers:
             if (symbol := self.symbols.get(tracer)) is None:
-                match tracer.aval:
-                    case ConcreteArray():
-                        symbol = Literal(tracer.aval)
-                    case ShapedArray():
-                        symbol = Var(tracer.aval)
-                    case _:
-                        raise RuntimeError('Unexpected abstract value of type '
-                                           f'{type(tracer.aval)}.')
+                if isinstance(tracer.value, AbstractValue | Tracer):
+                    symbol = Var(tracer.aval)
+                elif isinstance(tracer.aval, AbstractValue):
+                    symbol = Literal(tracer.value, tracer.aval)
+                else:
+                    raise RuntimeError('Unexpected abstract value of type '
+                                       f'{type(tracer.aval)}.')
                 self.symbols[tracer] = symbol
             symbols += [symbol]
         return symbols
@@ -524,7 +543,9 @@ def dump_yson(expr: Expr, fileobj: IO[bytes], indent: int = 2):
         elif isinstance(val, Jaxpr):
             return val.pretty_print(use_color=False)
         elif callable(val):
-            return f'{val.__module__}.{val.__name__}'
+            name = getattr(val, '__name__', type(val).__name__)
+            module = getattr(val, '__module__', type(val).__module__)
+            return f'{module}.{name}'
         elif hasattr(val, 'dtype'):
             return str(val.dtype)
         else:
@@ -565,7 +586,9 @@ def dump_xml(expr: Expr, fileobj: IO[str], indent: int = 2):
         elif isinstance(val, Jaxpr):
             return val.pretty_print(use_color=False)
         elif callable(val):
-            return f'{val.__module__}.{val.__name__}'
+            name = getattr(val, '__name__', type(val).__name__)
+            module = getattr(val, '__module__', type(val).__module__)
+            return f'{module}.{name}'
         elif hasattr(val, 'dtype'):
             return str(val.dtype)
         else:


### PR DESCRIPTION
### Summary

- Replaced removed JAX tracing internals (`MainTrace`, `Sublevel`, `new_main`, `ConcreteArray`) with the JAX 0.9 current-trace flow.
- Kept private JAX API usage narrow and isolated to `set_current_trace`, which is still needed for custom trace activation.
- Reworked literal symbols to store concrete values separately from their abstract values.
- Added coverage for mixed tracer/literal expressions such as x > 0 to ensure `make_mox` and `eval_mox` round-trip correctly.
