### PR TITLE
Add static branching expression to MoX

### DIFF
--- a/doc/yeps/YEP-0001.md
+++ b/doc/yeps/YEP-0001.md
@@ -1,0 +1,375 @@
+# YAX Enhancement Proposal: Static Branching for MoX
+
+Status: draft
+
+## Summary
+
+Add a first-class static branch expression to MoX so a substituted node can be
+replaced with one of several alternative expressions selected by a
+Python-static input. This supports transformations in which a layer has
+multiple execution modes, such as factorized Dense replacements selected with
+`mode='K'`, `mode='L'`, `mode='S'`, or `mode='W'`.
+
+A typical use looks as the following.
+
+```python
+replacement = yax.branch('mode', {
+    'K': k_mox,
+    'L': l_mox,
+    'S': s_mox,
+    'W': w_mox,
+})
+
+mox = yax.sub('//[@primitive="module_call"][@type="Dense"]', replacement, mox)
+ys = yax.eval_mox(mox, params, xs, mode='K')
+```
+
+Only the selected case is evaluated. Unsupported selector values fail with a
+clear error. Branch parameters live in one shared namespace, so different cases
+may reference the same parameter symbol while the runtime parameter tree stores
+that parameter once.
+
+## Motivation
+
+Today, Python control flow over static values is resolved during tracing. If a
+module is traced with `mode='W'`, the resulting MoX contains only the `W` path.
+The `K`, `L`, and `S` paths are not represented and cannot be selected later by
+`eval_mox`.
+
+This is too restrictive for module substitution workflows where one logical
+replacement needs multiple small MoX implementations behind a static selector.
+MoX should keep those alternatives structurally visible while preserving the
+existing invariant that each primitive or module expression has explicit input
+and output symbols.
+
+## Goals
+
+- Represent static branching explicitly in the MoX tree.
+- Allow branch selectors to be passed as named static kwargs to `eval_mox`.
+- Evaluate exactly one selected case.
+- Support string and boolean case keys in the first version.
+- Preserve existing substitution invariants for input and output symbols.
+- Preserve cross-case parameter sharing for parameters with the same declared
+  variable path.
+- Make branch nodes discoverable by traversal, dumping, and query helpers.
+- Keep ordinary `Equation` and `Mox` behavior unchanged.
+
+## Non-Goals
+
+- Do not implement array-dependent dynamic control flow. This proposal is not a
+  replacement for `jax.lax.switch`, `jax.lax.cond`, or traced JAX predicates.
+- Do not trace all Python branches automatically from one function body.
+  Alternatives are supplied as already-built MoX expressions.
+- Do not add a default branch in the first version.
+- Do not infer parameter aliases from equal values or similar names. Cross-case
+  sharing is derived from identical variable paths with compatible abstract
+  values. Different variable paths are different logical parameters, even if
+  they contain the same original symbol or equal runtime arrays.
+
+## Public API
+
+Add three public exports:
+
+```python
+class Static(Symbol[Any]):
+    ...
+
+
+class Branch(Expr):
+    ...
+
+
+def branch(
+    selector_name: str,
+    cases: Mapping[str | bool | np.bool_, Expr],
+    *,
+    name: str | None = None,
+) -> Branch:
+    ...
+```
+
+`selector_name` is the keyword name used at evaluation time. `cases` maps
+supported static values to replacement expressions. `name` optionally controls
+the parameter-tree name used when the branch replaces a module node. If omitted,
+substitution should preserve the replaced node's name when possible.
+
+Example:
+
+```python
+mox = yax.sub(xpath, yax.branch('mode', {'K': k_expr, 'W': w_expr}), mox)
+out = yax.eval_mox(mox, params, x, mode='W')
+```
+
+## Expression Model
+
+Introduce a new `Expr` subtype:
+
+```python
+BranchKey = str | bool
+
+
+@dataclass(slots=True, eq=False)
+class Static(Symbol[Any]):
+    name: str = ''
+
+
+@dataclass(slots=True)
+class Branch(Expr):
+    selector_name: str
+    selector: Static
+    cases: dict[BranchKey, Expr]
+    var_tree: PyTreeDef = field(default_factory=default_treedef)
+```
+
+`Branch` is not a `Mox`. A `Mox` means "evaluate this module expression" or
+"call this concrete Flax module". A branch has different semantics: select one
+case by a static value, then evaluate only that case.
+
+Semantically, `Static` carries a named Python value, not a JAX abstract value.
+The exact dataclass field order can follow the existing `Symbol` inheritance,
+but callers should treat `name` as the runtime kwarg name.
+
+`Branch.inputs` should follow the existing `Mox` convention for parameter
+leaves: shared parameter symbols come first and are described by `var_tree`.
+The branch selector follows the parameter leaves, and external data inputs come
+after the selector.
+
+```python
+num_vars = branch.var_tree.num_leaves
+shared_params = branch.inputs[:num_vars]
+selector = branch.inputs[num_vars]
+external_inputs = branch.inputs[num_vars + 1:]
+```
+
+Each case expression should reference shared parameter symbols directly for
+paths that are shared. If two cases use parameter path `('params', 'V')`, both
+cases should read the same `Symbol`, rather than case-local copies. Different
+parameter paths remain different runtime leaves even if they appear in only one
+case.
+
+## Case Validation
+
+`branch(...)` should validate the cases before returning a `Branch`.
+
+- `cases` must be non-empty.
+- Keys are normalized before storage.
+  - `np.bool_` becomes `bool`.
+  - `str` is preserved.
+- Unsupported key types are rejected.
+- Duplicate normalized keys are rejected.
+- All cases must have the same number of external inputs.
+- All cases must have the same number of outputs.
+- Corresponding external inputs and outputs must match by shape and dtype.
+- Parameter leaves from all cases are merged into one branch variable tree that
+  preserves the union of distinct variable paths.
+- Repeated parameter paths across cases must have matching shape and dtype.
+- Repeated parameter paths are represented by one shared symbol in the branch.
+- Different parameter paths remain present as distinct runtime leaves.
+- The same original parameter symbol must not appear at multiple different
+  variable paths. This is ambiguous in V1 because later expression uses refer
+  to symbols, not parameter paths.
+
+For `Mox` cases, external inputs exclude parameter leaves:
+
+```python
+external_inputs = case.inputs[case.var_tree.num_leaves:]
+```
+
+For `Equation` cases, all inputs are external inputs.
+
+## Evaluation Semantics
+
+`eval_mox` should use branch-aware recursive evaluation rather than only
+unconditional tree traversal.
+
+Evaluation rules:
+
+- `Equation`: execute the primitive as today.
+- concrete `Mox`: call the stored Flax module as today.
+- ephemeral `Mox`: evaluate children in order as today.
+- `Branch`: read the selector, normalize it, select `cases[key]`, and evaluate
+  only that expression.
+
+Unsupported modes should raise `ValueError` with the selector name, bad value,
+and available keys.
+
+Branch selectors are Python-static values. If users wrap `eval_mox` with
+`jax.jit`, the selector argument must be static from JAX's point of view.
+
+## Static Inputs
+
+Static branch selectors need different semantics from ordinary static values.
+
+Ordinary traced static values are part of the traced program. If tracing follows
+one Python path, evaluating with a different static value should not silently
+pretend the other path exists. Such values should be validated against their
+traced value.
+
+Branch selectors are intentionally variable over the declared case set. They
+should be represented with `Static` symbols and accepted at evaluation time if
+the normalized value is one of the case keys.
+
+In the first version, static selector wiring is explicit through `branch(...)`.
+Generic string inputs to arbitrary traced functions do not need to become
+re-traceable branch selectors.
+
+## Substitution Semantics
+
+Extend substitution to accept `Branch` wherever it currently accepts an
+`Equation` or `Mox` replacement.
+
+When a selected node is replaced by a branch:
+
+- The branch output symbols are rewired to the original node outputs.
+- Each case's external inputs are rewired to the original node external inputs.
+- The selector is not part of the replaced node's input boundary.
+- Case parameter symbols are remapped into the branch's shared parameter
+  namespace.
+- Case-local auxiliary non-parameter inputs remain auxiliary inputs.
+- Parent `in_tree` objects are updated for any new auxiliary inputs.
+- The named static selector is added as a root kwarg if absent.
+- Multiple branches with the same selector name reuse the same root selector
+  symbol instead of appending duplicate `mode` kwargs.
+- Every parent whose child list, `in_tree`, or `var_tree` changes is marked
+  ephemeral, matching current substitution behavior.
+
+This preserves the current replacement invariant. A replacement must be
+compatible with the node it replaces at the input/output boundary.
+
+## Parameter Trees
+
+V1 should use a shared branch parameter namespace. Cases are alternative
+computations over one replacement state, not independent modules with separate
+state. When a branch replaces a module node named `Dense_0`, its parameters are
+stored once under that replacement name.
+
+```python
+params = {
+    'params': {
+        'Dense_0': {
+            'V': ...,
+            'K': ...,
+            'L': ...,
+            'S': ...,
+            'U': ...,
+        },
+    },
+}
+```
+
+For example, case `'K'` may read `V` and `K`, while case `'W'` may read `V`,
+`S`, and `U`. The `V` parameter is represented by one symbol and one runtime
+parameter leaf.
+
+The merge rule is path-preserving and structural. Parameter leaves with the
+same variable path are shared if their abstract values match. A repeated path
+with a different shape or dtype is an error. Parameters that appear in only one
+case remain part of the same shared branch namespace. Other cases simply do not
+use them.
+
+Different variable paths are different runtime parameter leaves, following Flax
+semantics: parameter identity is its variable-tree path, not object equality of
+the arrays stored at those paths. A user may pass equal arrays at multiple
+paths, but equal values, equal object identity, or shared source symbol
+identity alone do not merge paths.
+
+V1 rejects a parameter tree where the same original `Symbol` appears at more
+than one variable path. MoX expressions refer to parameters by symbol, not by
+path, so such an alias would make it ambiguous which runtime path should feed a
+later use of that symbol. Rejecting this case keeps the branch `var_tree` free
+of duplicate symbols and preserves the existing evaluation invariant that every
+input symbol is written once.
+
+This avoids case-key levels in the parameter tree and preserves training
+semantics. Updates to `V` affect every mode that references path `V`, while
+unrelated paths keep their own runtime entries.
+
+Examples, using `/a` as shorthand for a variable-tree path and `S_*` for fresh
+branch symbols:
+
+```text
+{/a: s1} + {/a: s2}
+-> {/a: S_a}
+
+{/a: s1} + {/b: s2}
+-> {/a: S_a, /b: S_b}
+
+{/a: s1, /b: s1} + {/a: s2, /c: s2}
+-> error: s1 appears at both /a and /b
+```
+
+The last example is invalid even though the shapes may be compatible. Different
+Flax parameter paths must correspond to different symbols in V1.
+
+## Traversal and Serialization
+
+Branch nodes should be visible to inspection APIs.
+
+- `map_mox` should traverse all cases for inspection/transformation use cases.
+- `query` should include branch nodes and their descendants.
+- `dump`, `dump_xml`, and `dump_yson` should show the selector name and case
+  keys.
+- `to_dict` should emit `primitive='static_branch'`, `selector=<name>`, and a
+  case map.
+
+Evaluation should not rely on `map_mox`. It must execute only the selected
+case.
+
+## Error Handling
+
+Expected user-facing errors follow.
+
+- Empty case map.
+- Unsupported case key type.
+- Duplicate normalized case key.
+- Case input count, output count, shape, or dtype mismatch.
+- Missing selector kwarg at evaluation time.
+- Selector value not present in `cases`.
+- Attempt to use a JAX array or tracer as a branch selector.
+- Repeated parameter path with incompatible shape or dtype.
+- Same-symbol parameter alias across different variable paths.
+
+## Compatibility
+
+Existing MoX programs without `Branch` nodes should evaluate and serialize as
+before.
+
+Existing `sub(...)` calls with `Equation` or `Mox` replacements should keep the
+same behavior. The branch path should be additive and guarded by type checks.
+
+The current JAX compatibility pin should remain unchanged. This proposal does
+not require upgrading JAX.
+
+## Test Plan
+
+- Replace one Dense node with `branch('mode', {'K': k_mox, 'L': l_mox})`.
+- Verify `eval_mox(..., mode='K')` and `eval_mox(..., mode='L')` execute
+  different computations.
+- Verify only the selected case runs.
+- Verify an unsupported selector raises a clear `ValueError`.
+- Verify multiple substituted nodes can share one `mode` kwarg without
+  duplicating root inputs.
+- Verify repeated parameter paths across cases produce shared symbol identity
+  without duplicating the runtime path.
+- Verify distinct parameter paths remain present in the merged runtime tree.
+- Verify same-symbol aliases across distinct paths are rejected.
+- Verify the runtime parameter tree has no case-key level for shared params.
+- Verify updating a shared parameter affects every mode that references it.
+- Verify conflicting repeated parameter paths are rejected when shape or dtype
+  differs.
+- Verify boolean case keys work.
+- Verify string case keys work.
+- Verify validation rejects mismatched case input/output counts, shapes, and
+  dtypes.
+- Verify `query`, `dump`, `dump_xml`, and `dump_yson` expose branch structure.
+- Verify existing substitution and evaluation tests still pass.
+
+## Open Questions
+
+- Should a later version support explicit parameter aliases across different
+  variable paths?
+- Should `branch(...)` accept an optional `default` case later?
+- Should static selector keys support integers and enums, or only strings and
+  booleans?
+- Should `make_mox` grow a general static-argument API, or should static
+  branching remain explicit through `branch(...)`?

--- a/tests/branch_test.py
+++ b/tests/branch_test.py
@@ -14,12 +14,13 @@
 
 from collections.abc import Mapping
 
+import flax.linen as nn
 import jax.numpy as jnp
 import numpy as np
 import pytest
-import flax.linen as nn
+from numpy.testing import assert_array_equal
 
-from yax import Static, branch, make_mox, merge_branch_params
+from yax import Static, branch, make_mox, map_param_tree, reconstruct
 
 
 def absolute(xs):
@@ -63,8 +64,44 @@ class Scale(nn.Module):
         return xs * scale
 
 
-def test_merge_branch_params():
-    pass
+def test_reconstruct_dict_dict():
+    res = reconstruct({('a', 'a'): 1, ('a', 'b'): 2, ('b', 'a'): 3})
+    assert res['a']['a'] == 1
+    assert res['a']['b'] == 2
+    assert res['b']['a'] == 3
+
+
+def test_reconstruct_dict_list():
+    res = reconstruct({('a', 0): 1, ('a', 1): 2, ('b', 'a'): 3})
+    assert res['a'] == [1, 2]
+    assert res['b']['a'] == 3
+
+
+def test_reconstruct_list_dict():
+    res = reconstruct({(0, 'a'): 1, (0, 'b'): 2, (1, 'a'): 3})
+    assert res[0]['a'] == 1
+    assert res[0]['b'] == 2
+    assert res[1]['a'] == 3
+
+
+def test_reconstruct_interleaved():
+    with pytest.raises(RuntimeError, match='interleave together'):
+        reconstruct({('a', 'a'): 1, ('a', 'b'): 2, ('a', ): 3})
+
+
+def test_map_param_tree():
+    xs = {'params': {'kernel': jnp.eye(2)}}
+    ys = {'params': {'bias': jnp.zeros(2)}}
+
+    def fn(leaves):
+        for leaf in (x for x in leaves if x is not None):
+            return leaf
+        else:
+            raise RuntimeError(f'No defined leaves: {leaves}.')
+
+    res = map_param_tree(fn, (xs, ys))
+    assert_array_equal(res['params']['kernel'], xs['params']['kernel'])
+    assert_array_equal(res['params']['bias'], ys['params']['bias'])
 
 
 def test_branch_key_normalization():

--- a/tests/branch_test.py
+++ b/tests/branch_test.py
@@ -303,6 +303,24 @@ def test_only_selected_case_runs_with_shared_outputs():
     assert_allclose(eval_mox(mox, {}, xs, mode='abs'), absolute(xs))
 
 
+def test_branch_jittable():
+    xs = jnp.array([-1.0, 2.0])
+    mox = pass_mox(xs)
+    replacement = branch('mode', {
+        'neg': make_eq(negate),
+        'abs': make_eq(absolute),
+    })
+    sub('//[@type="Pass"]', replacement, mox)
+
+    def apply(params, xs, *, mode: str):
+        return eval_mox(mox, params, xs, mode=mode)
+
+    apply = jax.jit(apply, static_argnames=('mode', ))
+
+    assert_allclose(apply({}, xs, mode='neg'), negate(xs))
+    assert_allclose(apply({}, xs, mode='abs'), absolute(xs))
+
+
 def test_shared_parameter_path_uses_one_runtime_leaf():
     xs = jnp.ones((2,))
     replacement = branch('mode', {

--- a/tests/branch_test.py
+++ b/tests/branch_test.py
@@ -13,14 +13,18 @@
 # limitations under the License.
 
 from collections.abc import Mapping
+from typing import Type, cast
 
 import flax.linen as nn
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-from yax import Static, branch, make_mox, map_param_tree, reconstruct
+from yax import (
+    ShapedArray, Static, Symbol, branch, make_mox, map_param_tree,
+    merge_branch_params, reconstruct)
 
 
 def absolute(xs):
@@ -60,8 +64,23 @@ class Scale(nn.Module):
 
     @nn.compact
     def __call__(self, xs):
-        scale = self.param('scale', nn.initializers.ones, xs.shape)
-        return xs * scale
+        *_, features = xs.shape
+        kernel = self.param('scale', nn.initializers.ones, (features, ) * 2)
+        return xs @ kernel
+
+
+class Shift(nn.Module):
+
+    @nn.compact
+    def __call__(self, xs):
+        *_, features = xs.shape
+        shift = self.param('shift', nn.initializers.ones, (features, ))
+        return xs + shift
+
+
+def test_reconstruct_empty():
+    res = reconstruct({})
+    assert res == {}
 
 
 def test_reconstruct_dict_dict():
@@ -102,6 +121,33 @@ def test_map_param_tree():
     res = map_param_tree(fn, (xs, ys))
     assert_array_equal(res['params']['kernel'], xs['params']['kernel'])
     assert_array_equal(res['params']['bias'], ys['params']['bias'])
+
+
+def test_merge_branch_params():
+    xs = jnp.empty((2, ))
+
+    def make_expr(module_ty: Type[nn.Module]):
+        module = module_ty()
+        params = module.init(jax.random.key(42), xs)
+        mox = make_mox(module.apply)(params, xs)
+        return mox.children[0]
+
+    scale = make_expr(Scale)
+    shift = make_expr(Shift)
+
+    leaves, treedef, mappings = \
+        merge_branch_params({np.bool_(True): scale, False: shift})
+    variables = jax.tree.unflatten(treedef, leaves)
+
+    symbol: Symbol = variables['params']['scale']
+    value: ShapedArray = cast(ShapedArray, symbol.value)
+    assert value.shape == (2, 2)
+    assert value.dtype == jnp.float32
+
+    symbol: Symbol = variables['params']['shift']
+    value: ShapedArray = cast(ShapedArray, symbol.value)
+    assert value.shape == (2, )
+    assert value.dtype == jnp.float32
 
 
 def test_branch_key_normalization():

--- a/tests/branch_test.py
+++ b/tests/branch_test.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 from collections.abc import Mapping
+from io import BytesIO, StringIO
 from typing import Type, cast
+from xml.etree import ElementTree
 
 import flax.linen as nn
 import jax
@@ -174,3 +176,48 @@ def test_branch_boundary_validation():
 
     with pytest.raises(RuntimeError, match='output symbol shapes differ'):
         branch('mode', {'a': make_eq(), 'b': make_eq(first)})
+
+
+def test_dump():
+    expr = make_eq()
+    node = branch('mode', {np.bool_(True): expr, False: expr})
+    buf = StringIO()
+    dump(node, buf)
+    output = buf.getvalue()
+
+    # inputs =[Static(value='mode'), ...]
+    # outputs=[...]
+    # branch None : static_branch(selector=mode, cases=(True, False)) { # 0
+    #   case True { ... }
+    #   case False { ... }
+    # }
+    assert 'Static' in output
+    assert '\'mode\'' in output
+    assert 'branch' in output
+    assert 'static_branch' in output
+    assert 'case False {' in output
+    assert 'case True {' in output
+
+
+def test_dump_xml():
+    expr = make_eq()
+    node = branch('mode', {np.bool_(True): expr, False: expr})
+    buf = StringIO()
+    dump_xml(node, buf)
+    root = ElementTree.fromstring(buf.getvalue())
+    assert root.tag == 'static_branch'
+    assert root.attrib['selector'] == 'mode'
+
+
+def test_dump_yson():
+    yt_yson = pytest.importorskip('yt.yson')
+
+    expr = make_eq()
+    node = branch('mode', {np.bool_(True): expr, False: expr})
+    buf = BytesIO()
+
+    dump_yson(node, buf)
+    obj = yt_yson.loads(buf.getvalue())
+    assert obj.attributes['primitive'] == 'static_branch'
+    assert obj.attributes['selector'] == 'mode'
+    assert len(obj) == 2

--- a/tests/branch_test.py
+++ b/tests/branch_test.py
@@ -22,11 +22,12 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_allclose, assert_array_equal
 
 from yax import (
-    ShapedArray, Static, Symbol, branch, make_mox, map_param_tree,
-    merge_branch_params, reconstruct)
+    Branch, Mox, ShapedArray, Static, Symbol, Var, branch, dump, dump_xml,
+    dump_yson, eval_mox, make_mox, map_param_tree, merge_branch_params, query,
+    reconstruct, sub)
 
 
 def absolute(xs):
@@ -90,6 +91,15 @@ class Scale(nn.Module):
         *_, features = xs.shape
         kernel = self.param('scale', nn.initializers.ones, (features, ) * 2)
         return xs @ kernel
+
+
+class ScalePlus(nn.Module):
+
+    @nn.compact
+    def __call__(self, xs):
+        *_, features = xs.shape
+        kernel = self.param('scale', nn.initializers.ones, (features, ) * 2)
+        return xs @ kernel + 1.0
 
 
 class Shift(nn.Module):
@@ -255,6 +265,186 @@ def test_dump_yson():
     assert len(obj) == 2
 
 
+def test_replace_module_with_branch_and_eval_modes():
+    xs = jnp.ones((2,))
+    mox = pass_mox(xs)
+    replacement = branch('mode', {
+        'scale': module_case(Scale(), xs),
+        'shift': module_case(Shift(), xs),
+    })
+
+    sub('//[@type="Pass"]', replacement, mox)
+    variables = {
+        'params': {
+            'Pass_0': {
+                'scale': jnp.eye(xs.shape[-1]) * 3.0,
+                'shift': jnp.full(xs.shape, 5.0),
+            },
+        },
+    }
+
+    assert_allclose(eval_mox(mox, variables, xs, mode='scale'), xs * 3.0)
+    assert_allclose(eval_mox(mox, variables, xs, mode='shift'), xs + 5.0)
+
+
+def test_only_selected_case_runs_with_shared_outputs():
+    xs = jnp.array([-1.0, 2.0])
+    mox = pass_mox(xs)
+    replacement = branch('mode', {
+        'neg': make_eq(negate),
+        'abs': make_eq(absolute),
+    })
+
+    sub('//[@type="Pass"]', replacement, mox)
+
+    # Both cases share output symbols after branch construction. Evaluating
+    # both cases would attempt to write the same symbol twice.
+    assert_allclose(eval_mox(mox, {}, xs, mode='neg'), negate(xs))
+    assert_allclose(eval_mox(mox, {}, xs, mode='abs'), absolute(xs))
+
+
+def test_shared_parameter_path_uses_one_runtime_leaf():
+    xs = jnp.ones((2,))
+    replacement = branch('mode', {
+        'scale': module_case(Scale(), xs),
+        'plus': module_case(ScalePlus(), xs),
+    })
+
+    assert replacement.var_tree.num_leaves == 1
+    [shared] = replacement.inputs[:replacement.var_tree.num_leaves]
+    for case in replacement.cases.values():
+        assert case.inputs[0] is shared
+
+    mox = pass_mox(xs)
+    sub('//[@type="Pass"]', replacement, mox)
+
+    variables = {'params': {'Pass_0': {'scale': jnp.eye(xs.shape[-1]) * 2.0}}}
+    assert_allclose(eval_mox(mox, variables, xs, mode='scale'), xs * 2.0)
+    assert_allclose(eval_mox(mox, variables, xs, mode='plus'), xs * 2.0 + 1.0)
+
+    variables = {'params': {'Pass_0': {'scale': jnp.eye(xs.shape[-1]) * 4.0}}}
+    assert_allclose(eval_mox(mox, variables, xs, mode='scale'), xs * 4.0)
+    assert_allclose(eval_mox(mox, variables, xs, mode='plus'), xs * 4.0 + 1.0)
+
+
+def test_same_symbol_alias_in_one_tree_is_rejected():
+    param = Var(ShapedArray((2,), jnp.float32))
+    xs = Var(ShapedArray((2,), jnp.float32))
+    ys = Var(ShapedArray((2,), jnp.float32))
+    params, var_tree = jax.tree.flatten({'params': {'a': param, 'b': param}})
+    case = Mox(params + [xs], [ys], {}, var_tree=var_tree)
+
+    with pytest.raises(RuntimeError, match='multiple variable paths'):
+        branch('mode', {'a': case, 'b': case})
+
+
+def test_same_symbol_alias_across_case_paths_is_rejected():
+    param = Var(ShapedArray((2,), jnp.float32))
+    xs = Var(ShapedArray((2,), jnp.float32))
+    ys = Var(ShapedArray((2,), jnp.float32))
+    lhs_params, lhs_tree = jax.tree.flatten({'params': {'a': param}})
+    rhs_params, rhs_tree = jax.tree.flatten({'params': {'b': param}})
+    lhs = Mox(lhs_params + [xs], [ys], {}, var_tree=lhs_tree)
+    rhs = Mox(rhs_params + [xs], [ys], {}, var_tree=rhs_tree)
+
+    with pytest.raises(RuntimeError, match='multiple variable paths'):
+        branch('mode', {'lhs': lhs, 'rhs': rhs})
+
+
+def test_incompatible_repeated_parameter_path_is_rejected():
+    xs = Var(ShapedArray((2,), jnp.float32))
+    ys = Var(ShapedArray((2,), jnp.float32))
+    lhs_param = Var(ShapedArray((2,), jnp.float32))
+    rhs_param = Var(ShapedArray((3,), jnp.float32))
+    lhs_params, lhs_tree = jax.tree.flatten({'params': {'scale': lhs_param}})
+    rhs_params, rhs_tree = jax.tree.flatten({'params': {'scale': rhs_param}})
+    lhs = Mox(lhs_params + [xs], [ys], {}, var_tree=lhs_tree)
+    rhs = Mox(rhs_params + [xs], [ys], {}, var_tree=rhs_tree)
+
+    with pytest.raises(RuntimeError, match='Parameter symbol shapes differ'):
+        branch('mode', {'lhs': lhs, 'rhs': rhs})
+
+
+def test_incompatible_repeated_parameter_path_dtype_is_rejected():
+    xs = Var(ShapedArray((2,), jnp.float32))
+    ys = Var(ShapedArray((2,), jnp.float32))
+    lhs_param = Var(ShapedArray((2,), jnp.float32))
+    rhs_param = Var(ShapedArray((2,), jnp.int32))
+    lhs_params, lhs_tree = jax.tree.flatten({'params': {'scale': lhs_param}})
+    rhs_params, rhs_tree = jax.tree.flatten({'params': {'scale': rhs_param}})
+    lhs = Mox(lhs_params + [xs], [ys], {}, var_tree=lhs_tree)
+    rhs = Mox(rhs_params + [xs], [ys], {}, var_tree=rhs_tree)
+
+    with pytest.raises(RuntimeError, match='Parameter symbol dtypes differ'):
+        branch('mode', {'lhs': lhs, 'rhs': rhs})
+
+
+def test_multiple_branches_share_one_root_selector():
+    xs = jnp.array([-1.0, 2.0])
+    model = TwoPass()
+    params = model.init(jax.random.key(0), xs)
+    mox = make_mox(model.apply)(params, xs)
+    replacement = branch('mode', {
+        'neg': make_eq(negate),
+        'abs': make_eq(absolute),
+    })
+
+    sub('//[@type="Pass"]', replacement, mox)
+
+    selectors = [sym for sym in mox.inputs if isinstance(sym, Static)]
+    assert len(selectors) == 1
+    assert selectors[0].name == 'mode'
+    assert_allclose(eval_mox(mox, {}, xs, mode='neg'), negate(xs) * 2.0)
+    assert_allclose(eval_mox(mox, {}, xs, mode='abs'), absolute(xs) * 2.0)
+
+
+def test_bool_selector_and_eval_errors():
+    xs = jnp.ones((2,))
+    mox = pass_mox(xs)
+    sub('//[@type="Pass"]', branch('flag', {
+        True: make_eq(negate),
+        False: make_eq(absolute),
+    }), mox)
+
+    assert_allclose(eval_mox(mox, {}, xs, flag=True), negate(xs))
+    assert_allclose(eval_mox(mox, {}, xs, flag=np.bool_(False)), absolute(xs))
+    with pytest.raises(KeyError, match='Missing static branch selector'):
+        eval_mox(mox, {}, xs)
+    with pytest.raises(ValueError, match='Unsupported value'):
+        eval_mox(mox, {}, xs, flag='bad')
+    with pytest.raises(TypeError, match='must be a Python str or bool'):
+        eval_mox(mox, {}, xs, flag=jnp.array(True))
+
+
+def test_selector_conflict_with_existing_non_static_kwarg():
+    def fn(xs, mode: bool = False):
+        if mode:
+            return jnp.abs(xs)
+        return -xs
+
+    xs = jnp.array([-1.0, 2.0])
+    mox = make_mox(fn)(xs, mode=False)
+    replacement = branch('mode', {
+        'neg': make_eq(negate),
+        'abs': make_eq(absolute),
+    })
+
+    with pytest.raises(RuntimeError, match='already exists'):
+        sub('//jit', replacement, mox)
+
+
+def test_parameterized_branch_cannot_replace_primitive():
+    xs = jnp.ones((2,))
+    mox = make_mox(negate)(xs)
+    replacement = branch('mode', {
+        'scale': module_case(Scale(), xs),
+        'plus': module_case(ScalePlus(), xs),
+    })
+
+    with pytest.raises(NotImplementedError, match='primitive Equation'):
+        sub('//jit', replacement, mox)
+
+
 def test_branch_query_and_dumps():
     xs = jnp.ones((2,))
     mox = pass_mox(xs)
@@ -282,3 +472,15 @@ def test_branch_query_and_dumps():
     dump_yson(mox, buf)
     obj = yt_yson.loads(buf.getvalue())
     assert b'static_branch' in yt_yson.dumps(obj)
+
+
+def test_sub_inside_existing_branch_case_is_unsupported():
+    xs = jnp.ones((2,))
+    mox = pass_mox(xs)
+    sub('//[@type="Pass"]', branch('mode', {
+        'neg': make_eq(negate),
+        'abs': make_eq(absolute),
+    }), mox)
+
+    with pytest.raises(NotImplementedError, match='inside static branch'):
+        sub('//jit', make_eq(absolute), mox)

--- a/tests/branch_test.py
+++ b/tests/branch_test.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Daniel Bershatsky
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Mapping
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import flax.linen as nn
+
+from yax import Static, branch, make_mox, merge_branch_params
+
+
+def absolute(xs):
+    return jnp.abs(xs)
+
+
+def negate(xs):
+    return -xs
+
+
+def make_eq(fn=negate, shape=(2,)):
+    return make_mox(fn)(jnp.ones(shape)).children[0]
+
+
+class DuplicateCases(Mapping):
+
+    def __init__(self, items):
+        self._items = tuple(items)
+
+    def __iter__(self):
+        return (k for k, v in self._items)
+
+    def __len__(self):
+        return len(self._items)
+
+    def __getitem__(self, key):
+        for k, v in self._items:
+            if k is key:
+                return v
+        raise KeyError
+
+    def items(self):
+        return self._items
+
+
+class Scale(nn.Module):
+
+    @nn.compact
+    def __call__(self, xs):
+        scale = self.param('scale', nn.initializers.ones, xs.shape)
+        return xs * scale
+
+
+def test_merge_branch_params():
+    pass
+
+
+def test_branch_key_normalization():
+    expr = make_eq()
+    node = branch('mode', {np.bool_(True): expr, False: expr})
+
+    assert tuple(node.cases) == (True, False)
+    assert isinstance(node.inputs[node.var_tree.num_leaves], Static)
+
+    with pytest.raises(ValueError, match='Duplicate static branch key'):
+        branch('mode', DuplicateCases([(True, expr), (np.bool_(True), expr)]))
+    with pytest.raises(TypeError, match='Unsupported static branch key'):
+        branch('mode', {1: expr})
+    with pytest.raises(ValueError, match='at least one case'):
+        branch('mode', {})
+
+
+def test_branch_boundary_validation():
+    with pytest.raises(RuntimeError, match='input symbol shapes differ'):
+        branch('mode', {'a': make_eq(shape=(2,)), 'b': make_eq(shape=(3,))})
+
+    def first(xs):
+        return xs[:1]
+
+    with pytest.raises(RuntimeError, match='output symbol shapes differ'):
+        branch('mode', {'a': make_eq(), 'b': make_eq(first)})

--- a/tests/branch_test.py
+++ b/tests/branch_test.py
@@ -62,6 +62,27 @@ class DuplicateCases(Mapping):
         return self._items
 
 
+class Pass(nn.Module):
+
+    @nn.compact
+    def __call__(self, xs):
+        return xs + 0.0
+
+
+class SinglePass(nn.Module):
+
+    @nn.compact
+    def __call__(self, xs):
+        return Pass()(xs)
+
+
+class TwoPass(nn.Module):
+
+    @nn.compact
+    def __call__(self, xs):
+        return Pass(name='left')(xs) + Pass(name='right')(xs)
+
+
 class Scale(nn.Module):
 
     @nn.compact
@@ -78,6 +99,17 @@ class Shift(nn.Module):
         *_, features = xs.shape
         shift = self.param('shift', nn.initializers.ones, (features, ))
         return xs + shift
+
+
+def module_case(module: nn.Module, xs):
+    params = module.init(jax.random.key(0), xs)
+    return make_mox(module.apply)(params, xs).children[0]
+
+
+def pass_mox(xs):
+    model = SinglePass()
+    params = model.init(jax.random.key(1), xs)
+    return make_mox(model.apply)(params, xs)
 
 
 def test_reconstruct_empty():
@@ -221,3 +253,32 @@ def test_dump_yson():
     assert obj.attributes['primitive'] == 'static_branch'
     assert obj.attributes['selector'] == 'mode'
     assert len(obj) == 2
+
+
+def test_branch_query_and_dumps():
+    xs = jnp.ones((2,))
+    mox = pass_mox(xs)
+    sub('//[@type="Pass"]', branch('mode', {
+        'neg': make_eq(negate),
+        'abs': make_eq(absolute),
+    }), mox)
+
+    [node] = query('//static_branch', mox)
+    assert isinstance(node, Branch)
+    assert len(query('//jit', mox)) == 2
+    assert node.to_dict(False)['primitive'] == 'static_branch'
+
+    buf = StringIO()
+    dump(mox, buf)
+    assert 'static_branch' in buf.getvalue()
+
+    buf = StringIO()
+    dump_xml(mox, buf)
+    assert ElementTree.fromstring(buf.getvalue()).find('.//static_branch') \
+        is not None
+
+    yt_yson = pytest.importorskip('yt.yson')
+    buf = BytesIO()
+    dump_yson(mox, buf)
+    obj = yt_yson.loads(buf.getvalue())
+    assert b'static_branch' in yt_yson.dumps(obj)

--- a/tests/branch_test.py
+++ b/tests/branch_test.py
@@ -179,7 +179,7 @@ def test_merge_branch_params():
     scale = make_expr(Scale)
     shift = make_expr(Shift)
 
-    leaves, treedef, mappings = \
+    leaves, treedef, _ = \
         merge_branch_params({np.bool_(True): scale, False: shift})
     variables = jax.tree.unflatten(treedef, leaves)
 

--- a/tests/branch_test.py
+++ b/tests/branch_test.py
@@ -484,3 +484,50 @@ def test_sub_inside_existing_branch_case_is_unsupported():
 
     with pytest.raises(NotImplementedError, match='inside static branch'):
         sub('//jit', make_eq(absolute), mox)
+
+
+class Model(nn.Module):
+
+    @nn.compact
+    def __call__(self, xs):
+        return nn.Dense(3, use_bias=False)(xs)
+
+
+def test_sub_adapter():
+    """Real-world example specific to PEFT and low-rank adaptation."""
+    xs = jnp.arange(2, dtype=jnp.float32)
+
+    def make_expr(module_ty: Type[nn.Module], **kwargs) -> Mox:
+        module = module_ty(**kwargs)
+        params = module.init(jax.random.key(42), xs)
+        return make_mox(module.apply)(params, xs).children[0]
+
+    model = Model()
+    params = model.init(jax.random.key(0), xs)
+    mox = make_mox(model.apply)(params, xs)
+    [dense_no_bias] = query('//[@type="Dense"]', mox)
+    assert isinstance(dense_no_bias, Mox)
+
+    dense = make_expr(nn.Dense, features=3, use_bias=True)
+    br = branch('use_bias', {False: dense_no_bias, True: dense})
+
+    patched = sub('//[@type="Dense"]', br, mox)
+    variables = {
+        'params': {
+            'Dense_0': {
+                **params['params']['Dense_0'],
+                'bias': jnp.arange(3, dtype=jnp.float32),
+            },
+        },
+    }
+    ys = eval_mox(patched, variables, xs, use_bias=True)
+    zs = eval_mox(patched, variables, xs, use_bias=False)
+
+    dense_with_bias = nn.Dense(3, use_bias=True)
+    dense_without_bias = nn.Dense(3, use_bias=False)
+    ys_expected = dense_with_bias.apply(
+        {'params': variables['params']['Dense_0']}, xs)
+    zs_expected = dense_without_bias.apply(
+        {'params': {'kernel': variables['params']['Dense_0']['kernel']}}, xs)
+    assert_allclose(ys, ys_expected)
+    assert_allclose(zs, zs_expected)

--- a/yax.py
+++ b/yax.py
@@ -1716,7 +1716,7 @@ def query(expr: str | XPath, mox: Mox) -> Sequence[Any]:
     return nodes
 
 
-NodeSet: TypeAlias = Sequence[Mox | Equation]
+NodeSet: TypeAlias = Sequence[Mox | Equation | Branch]
 
 
 def filter_nodes(predicates: Sequence[LocationPredicate],
@@ -1729,7 +1729,7 @@ def filter_nodes(predicates: Sequence[LocationPredicate],
 
     nodes = []
     for node in node_set:
-        if isinstance(node, Mox):
+        if isinstance(node, Mox | Branch):
             attrs = node.to_dict(False)
         elif isinstance(node, Equation):
             attrs = node.to_dict()
@@ -1743,6 +1743,8 @@ def select_all_descendants(node_set: NodeSet) -> NodeSet:
     for node in node_set:
         if isinstance(node, Mox):
             nodes += select_all_descendants(node.children)
+        elif isinstance(node, Branch):
+            nodes += select_all_descendants(tuple(node.cases.values()))
     return tuple(nodes)
 
 
@@ -1751,6 +1753,8 @@ def select_children(node_set: NodeSet) -> NodeSet:
     for node in node_set:
         if isinstance(node, Mox):
             nodes += node.children
+        elif isinstance(node, Branch):
+            nodes += node.cases.values()
     return tuple(nodes)
 
 
@@ -1759,6 +1763,8 @@ def select_nodes(name: str, node_set: NodeSet) -> NodeSet:
         match node:
             case Mox():
                 return name == 'module_call'
+            case Branch():
+                return name == 'static_branch'
             case Equation():
                 return name == node.prim.name
 

--- a/yax.py
+++ b/yax.py
@@ -17,6 +17,7 @@ building, querying, and mutation.
 """
 
 import re
+from collections import defaultdict
 from copy import copy
 from dataclasses import dataclass, field, fields
 from functools import partial, wraps
@@ -24,7 +25,7 @@ from io import StringIO
 from json import dumps
 from typing import (
     IO, Any, ClassVar, Generic, Mapping, ParamSpec, Self, Sequence, Type,
-    TypeAlias, TypeVar)
+    TypeAlias, TypeVar, cast)
 from xml.etree.ElementTree import (
     Element, ElementTree, SubElement, indent as indent_etree)
 
@@ -41,6 +42,7 @@ from flax.typing import RNGSequences
 from jax._src.core import set_current_trace  # noqa: PLC2701
 from jax.core import AbstractValue, ShapedArray, Trace, Tracer, find_top_trace
 from jax.extend.core import ClosedJaxpr as Jaxpr
+from jax.tree_util import DictKey, SequenceKey
 
 # TODO(@daskol): Make PR on reexporting PyTreeDef.
 try:
@@ -55,6 +57,8 @@ __all__ = ('Branch', 'Equation', 'Expr', 'Literal', 'Mox', 'Static',
 # TODO(@daskol): Python 3.12 introduced new type parameter syntax (PEP-0695)
 # but some code quality tools (e.g. yapf) do not support this syntax.
 Args = ParamSpec('Args')
+
+ArrayTree: TypeAlias = Mapping[str, Any]
 
 
 class ModuleTracer(Tracer):
@@ -393,6 +397,27 @@ def external_inputs(expr: Expr) -> list[Symbol]:
     return expr.inputs[num_params:]
 
 
+def external_params(expr: Expr) -> list[Symbol]:
+    num_params = param_count(expr)
+    if isinstance(expr, Branch):
+        return expr.inputs[:num_params + 1]
+    return expr.inputs[:num_params]
+
+
+def external_param_tree(expr: Expr) -> ArrayTree:
+    leaves = external_params(expr)
+    match expr:
+        case Mox():
+            node = cast(Mox, expr)
+        case Branch():
+            node = cast(Branch, expr)
+        case _:
+            raise RuntimeError(
+                f'No treedef for an object of type {type(expr).__name__}.')
+    params = jax.tree.unflatten(node.var_tree, params)
+    return params
+
+
 def set_external_inputs(expr: Expr, inputs: Sequence[Symbol]) -> None:
     num_params = param_count(expr)
     if isinstance(expr, Branch):
@@ -472,6 +497,105 @@ def normalize_branch_key(key: Any, *, selector_name='selector') -> BranchKey:
             f'str or bool, not {type(key).__name__}.')
     raise TypeError(
         f'Unsupported static branch key {key!r} of type {type(key).__name__}.')
+
+
+Key: TypeAlias = str | int
+
+KeyPath: TypeAlias = tuple[DictKey | SequenceKey, ...]
+
+
+def unwrap_key_path(kp: KeyPath) -> tuple[str, ]:
+    parts = []
+    for part in kp:
+        match part:
+            case DictKey():
+                parts.append(part.key)
+            case SequenceKey():
+                parts.append(part.id)
+            case _:
+                raise RuntimeError(
+                    f'Unexpected type of key part: {type(part)}.')
+    return tuple(parts)
+
+
+def to_flat_dict(at: ArrayTree) \
+        -> tuple[dict[Key, Array], list[Key], PyTreeDef]:
+    ix: list[Key] = []
+    res: dict[Key, Array] = {}
+
+    def fn_leaf(leaf: tuple[KeyPath, Any]):
+        key = unwrap_key_path(leaf[0])
+        nonlocal ix, res
+        ix.append(key)
+        res[key] = leaf[1]
+
+    def fn_node(*args):
+        pass
+
+    leaves, treedef = jax.tree.flatten_with_path(at, is_leaf_takes_path=True)
+    treedef.walk(fn_node, fn_leaf, leaves)  # type: ignore[attr-defined]
+    return res, ix, treedef
+
+
+def from_flat_dict[T](ix: list[T], treedef: PyTreeDef,
+                      mapping: dict[T, Any]) -> ArrayTree:
+    leaves = [mapping[key] for key in ix]
+    return jax.tree.unflatten(treedef, leaves)
+
+
+def reconstruct(flat_dict: Mapping[Key, Any]):
+    """Reconstruct array tree from flat dictionary.
+
+    >>> reconstruct({('a', 'a'): 1, ('a', 'b'): 2, ('b', ): 3})
+    {'a': {'a': 1, 'b': 2}, 'b': 3}
+    >>> reconstruct({(0, 'a'): 1, (0, 'b'): 2, (1, 'a'): 3})
+    [{'a': 1, 'b': 2}, {'a': 3}]
+    """
+
+    if () in flat_dict and len(flat_dict) == 1:
+        return flat_dict[()]  # Leaf.
+    elif () in flat_dict:
+        raise RuntimeError(
+            f'Internal nodes and leaves interleave together: {flat_dict}.')
+
+    groups: dict[Key, Mapping[Key, Any]] = defaultdict(dict)
+    for key, leaf in flat_dict.items():
+        head, *rest = key
+        tail = tuple(rest)
+        groups[head][tail] = leaf
+
+    if isinstance(key := next(iter(groups)), int):
+        return [reconstruct(groups[i]) for i in range(len(groups))]
+
+    return {key: reconstruct(group) for key, group in groups.items()}
+
+
+def map_param_tree(fn: Callable[[Sequence[ArrayTree | None]], Any],
+                   trees: Sequence[ArrayTree] ) -> dict[str, Any]:
+    """Apply `fn` to all leaves of union of `trees`.
+
+    >>> xs = {'params': {'kernel': jnp.eye(2)}}
+    >>> ys = {'params': {'bias': jnp.zeros(2)}}
+    >>> fn = lambda args: [a for a in args if a is not None][0]
+    >>> res = map_param_tree(fn, (xs, ys))
+    >>> jax.tree.map(jnp.shape, res)
+    {'params': {'bias': (2,), 'kernel': (2, 2)}}
+    """
+    if len(trees) < 1:
+        raise RuntimeError('At least one tree requires.')
+
+    mappings, key_indices, _ = zip(*[to_flat_dict(tree) for tree in trees])
+
+    keys = set()
+    for key_index in key_indices:
+        keys |= set(key_index)
+
+    res: dict[KeyPath, Any] = {}
+    for key in sorted(keys):
+        args = [m.get(key) for m in mappings]
+        res[key] = fn(args)
+
+    return reconstruct(res)
 
 
 def merge_branch_params(cases: Mapping[BranchKey, Expr]) \

--- a/yax.py
+++ b/yax.py
@@ -980,8 +980,8 @@ def eval_mox(tree: Mox, *args, **kwargs):
 
     def read(var: Symbol) -> Any:
         """Read a symbol from execution context or take literal value."""
-        if (val := env.get(var)) is not None:
-            return val
+        if var in env:
+            return env[var]
         if isinstance(var, Literal):
             return var.const
         raise KeyError(f'Variable {var} is undefined.')
@@ -1255,10 +1255,10 @@ def validate_symbols(actual: list[Symbol], desired: list[Symbol],
     else:
         what = 'Symbol'
     if len(actual) != len(desired):
-        raise RuntimeError(f'Number of {what.tolower()} differ: '
+        raise RuntimeError(f'Number of {what.lower()} differ: '
                            f'{len(actual)} != {len(desired)}.')
     for pair in zip(actual, desired):
-        lhs, rhs = [s.value for s in pair]
+        lhs, rhs = [s.aval for s in pair]
         if lhs.shape != rhs.shape:
             raise RuntimeError(
                 f'{what} shapes differ: {lhs.shape} != {rhs.shape}.')

--- a/yax.py
+++ b/yax.py
@@ -387,6 +387,10 @@ def param_count(expr: Expr) -> int:
     return 0
 
 
+def param_symbols(expr: Expr) -> list[Symbol]:
+    return expr.inputs[:param_count(expr)]
+
+
 def external_inputs(expr: Expr) -> list[Symbol]:
     num_params = param_count(expr)
     if isinstance(expr, Branch):
@@ -402,7 +406,7 @@ def external_params(expr: Expr) -> list[Symbol]:
 
 
 def external_param_tree(expr: Expr) -> ArrayTree:
-    leaves = external_params(expr)
+    leaves = param_symbols(expr)
     match expr:
         case Equation():
             return {}
@@ -422,6 +426,14 @@ def set_external_inputs(expr: Expr, inputs: Sequence[Symbol]) -> None:
         expr.inputs = expr.inputs[:num_params + 1] + [*inputs]
     else:
         expr.inputs = expr.inputs[:num_params] + [*inputs]
+
+
+def expr_name(expr: Expr) -> str:
+    if name := expr.params.get('name'):
+        return name
+    if isinstance(expr, Mox) and expr.module_ty is not None:
+        return f'{expr.module_ty.__name__}_0'
+    return 'static_branch'
 
 
 def clone_symbol(sym: Symbol) -> Symbol:
@@ -517,9 +529,9 @@ def unwrap_key_path(kp: KeyPath) -> tuple[str, ]:
 
 
 def to_flat_dict(at: ArrayTree) \
-        -> tuple[dict[Key, Array], list[Key], PyTreeDef]:
+        -> tuple[dict[Key, Any], list[Key], PyTreeDef]:
     ix: list[Key] = []
-    res: dict[Key, Array] = {}
+    res: dict[Key, Any] = {}
 
     def fn_leaf(leaf: tuple[KeyPath, Any]):
         key = unwrap_key_path(leaf[0])
@@ -570,7 +582,7 @@ def reconstruct(flat_dict: Mapping[Key, Any]):
 
 
 def map_param_tree(fn: Callable[[Sequence[ArrayTree | None]], Any],
-                   trees: Sequence[ArrayTree] ) -> dict[str, Any]:
+                   trees: Sequence[ArrayTree]) -> dict[str, Any]:
     """Apply `fn` to all leaves of union of `trees`.
 
     >>> xs = {'params': {'kernel': jnp.eye(2)}}
@@ -599,7 +611,7 @@ def map_param_tree(fn: Callable[[Sequence[ArrayTree | None]], Any],
 
 def merge_branch_params(cases: Mapping[BranchKey, Expr]) \
         -> tuple[list[Symbol], PyTreeDef, dict[Symbol, Symbol]]:
-    """Merge case parameter symbols by variable path and symbol identity.
+    """Merge case parameter symbols by variable path.
 
     1. Restore param tree.
     2. Symbols at the same paths are the same symbols.
@@ -613,28 +625,43 @@ def merge_branch_params(cases: Mapping[BranchKey, Expr]) \
         param_tree = external_param_tree(expr)
         param_trees += [param_tree]
 
-    def fn(leaves: Sequence[ArrayTree | None]) -> ArrayTree:
-        symbols: Sequence[Symbol] = [x for x in leaves if x is not None]
-        if len(symbols) == 0:
-            raise RuntimeError(f'No array tree defined: {leaves}.')
-        symbol, *symbols = symbols
-        return symbol
-
-    # Build union tree of parameter trees.
-    params = map_param_tree(fn, param_trees)
-    leaves, treedef = jax.tree.flatten(params)
-
-    # Build mapping between shared symbols and branch arm symbols.
-    mapping: dict[Symbol, Symbol] = {}
-    flat_params, *_ = to_flat_dict(params)
+    # First validate the V1 ambiguity rule. MoX expressions refer to params by
+    # symbol, not path, so one symbol cannot safely stand for multiple runtime
+    # paths.
+    symbol_paths: dict[Symbol, KeyPath] = {}
+    path_symbols: dict[KeyPath, list[Symbol]] = defaultdict(list)
+    keys: list[KeyPath] = []
     for param_tree in param_trees:
-        flat_param_tree, *_ = to_flat_dict(param_tree)
-        for key, sym in flat_param_tree.items():
-            if (shared_sym := flat_params[key]) == sym:
-                continue
+        flat_param_tree, key_index, _ = to_flat_dict(param_tree)
+        for key in key_index:
+            sym = flat_param_tree[key]
+            if not isinstance(sym, Symbol):
+                raise RuntimeError(
+                    f'Expected a Symbol at parameter path {key}: {sym}.')
+            if (path := symbol_paths.get(sym)) is not None and path != key:
+                raise RuntimeError(
+                    f'Parameter symbol appears at multiple variable paths: '
+                    f'{path} and {key}.')
+            symbol_paths[sym] = key
+            if key not in path_symbols:
+                keys += [key]
+            path_symbols[key].append(sym)
+
+    shared_params: dict[KeyPath, Symbol] = {}
+    mapping: dict[Symbol, Symbol] = {}
+    for key in keys:
+        symbol, *symbols = path_symbols[key]
+        for sym in symbols:
+            validate_symbols([symbol], [sym], 'parameter')
+        shared_sym = clone_symbol(symbol)
+        shared_params[key] = shared_sym
+        for sym in [symbol] + symbols:
             mapping[sym] = shared_sym
 
-    # Then replace branch symbols with shared ones.
+    params = reconstruct(shared_params)
+    leaves, treedef = jax.tree.flatten(params)
+
+    # Then replace branch symbols with shared branch symbols.
     for _, expr in cases.items():
         replace_symbols(expr, mapping)
 
@@ -651,6 +678,7 @@ def branch(selector_name: str,
         raise ValueError('Static branch requires at least one case.')
 
     normalized: dict[BranchKey, Expr] = {}
+    memo: dict[Symbol, Symbol] = {}
     for key, expr in cases.items():
         norm_key = normalize_branch_key(key, selector_name=selector_name)
         if norm_key in normalized:
@@ -659,7 +687,7 @@ def branch(selector_name: str,
             raise TypeError(
                 f'Branch case {norm_key!r} must be an {type(Expr).__name__}, '
                 f'not {type(expr).__name__}.')
-        normalized[norm_key] = clone_expr(expr)
+        normalized[norm_key] = clone_expr(expr, memo)
 
     first_case = next(iter(normalized.values()))
     first_inputs = [*external_inputs(first_case)]
@@ -1427,6 +1455,8 @@ def map_mox(fn: Callable[[Expr], Any], tree: Mox):
         node: Expr = nodes.pop()
         if isinstance(res := fn(node), Mox):
             nodes += reversed(res.children)
+        elif isinstance(res, Branch):
+            nodes += reversed(tuple(res.cases.values()))
 
 
 ModulePath: TypeAlias = tuple[str, ...]
@@ -1436,8 +1466,8 @@ ModulePath: TypeAlias = tuple[str, ...]
 SubFn: TypeAlias = Callable[[ModulePath, Expr], Expr]
 
 
-def sub(expr: str | XPath | Sequence[Equation | Mox],
-        repl: Mox | Equation | SubFn, mox: Mox) -> Mox:
+def sub(expr: str | XPath | Sequence[Equation | Mox | Branch],
+        repl: Mox | Equation | Branch | SubFn, mox: Mox) -> Mox:
     """Substitute a module expression `mox` with `repl` according to matching
     pattern `expr`.
 
@@ -1455,10 +1485,7 @@ def sub(expr: str | XPath | Sequence[Equation | Mox],
         which is not deepcopy-able. This is why we shallow-copy `repl` and
         create new symbols.
         """
-        obj = copy(repl)
-        obj.inputs = [type(s)(s.value) for s in repl.inputs]
-        obj.outputs = [type(s)(s.value) for s in repl.outputs]
-        return obj
+        return clone_expr(repl)
 
     sub_fn: SubFn
     if isinstance(repl, Expr):
@@ -1470,12 +1497,12 @@ def sub(expr: str | XPath | Sequence[Equation | Mox],
 
     # Our substitution algorithm is quite straight forward: find nodes of
     # interest, verify type integrity, search parents, and finally replace.
-    nodes: list[Equation | Mox] = []
+    nodes: list[Equation | Mox | Branch] = []
     if isinstance(expr, list | tuple):
         nodes.extend(expr)
     else:
         for node in query(expr, mox):
-            if not isinstance(node, Equation | Mox):
+            if not isinstance(node, Equation | Mox | Branch):
                 raise RuntimeError(
                     f'XPath expression does not select a node: {expr}.')
             nodes += [node]
@@ -1483,9 +1510,12 @@ def sub(expr: str | XPath | Sequence[Equation | Mox],
     for node in nodes:
         if not (parents := find_parents(mox, node)):
             raise RuntimeError(f'No parent found for node {node}.')
+        if any(isinstance(parent, Branch) for parent in parents):
+            raise NotImplementedError(
+                'Substitution inside static branch cases is not supported.')
         path = tuple([p.params.get('name') or p.module_ty.__name__
-                      for p in parents[1:]])
-        path += (node.params.get('name') or node.module_ty.__name__, )
+                      for p in parents[1:] if isinstance(p, Mox)])
+        path += (expr_name(node), )
         if (new_node := sub_fn(path, node)) is node:
             continue
         sub_node(mox, node, new_node)
@@ -1493,11 +1523,20 @@ def sub(expr: str | XPath | Sequence[Equation | Mox],
     return mox
 
 
-def sub_node(mox: Mox, node: Expr, repl: Equation | Mox):
+def sub_node(mox: Mox, node: Expr, repl: Equation | Mox | Branch):
     if not (parents := find_parents(mox, node)):
         raise RuntimeError(f'No parent found for node {node}.')
+    if any(isinstance(parent, Branch) for parent in parents):
+        raise NotImplementedError(
+            'Substitution inside static branch cases is not supported.')
+    if (isinstance(node, Equation) and isinstance(repl, Branch)
+            and param_count(repl)):
+        raise NotImplementedError(
+            'Parameterized Branch replacement of a primitive Equation is not '
+            'supported.')
 
     *_, parent = parents
+    assert isinstance(parent, Mox)
     for ix, child in enumerate(parent.children):
         if child is node:
             break
@@ -1505,18 +1544,31 @@ def sub_node(mox: Mox, node: Expr, repl: Equation | Mox):
         raise RuntimeError(
             f'There is no node {node} among childrens of {parent}.')
 
+    if (isinstance(repl, Branch) and not repl.params.get('name')
+            and node.params.get('name')):
+        repl.params['name'] = node.params.get('name')
     rewire_node(node, repl)
+    if isinstance(repl, Branch):
+        ensure_root_static_kwarg(mox, repl)
     update_in_trees(parents, ix, repl)
     update_var_trees(parents, ix, repl)
     parent.children[ix] = repl
 
 
-def find_parents(root: Expr, node: Expr) -> tuple[Mox, ...]:
+def find_parents(root: Expr, node: Expr) -> tuple[Expr, ...] | None:
     # TODO(@daskol): We should get rid of `find_parents` and add `parent`
     # reference to `Expr` type.
     match root:
         case Equation():
             return None
+        case Branch():
+            for expr in root.cases.values():
+                if expr is node:
+                    return (root, )
+            for expr in root.cases.values():
+                parents = find_parents(expr, node)
+                if parents is not None:
+                    return (root, ) + parents
         case Mox():
             # Try to find `node` in childrens.
             for expr in root.children:
@@ -1529,18 +1581,33 @@ def find_parents(root: Expr, node: Expr) -> tuple[Mox, ...]:
                     return (root, ) + parents
 
 
-def rewire_node(node: Expr, repl: Expr):
-    if isinstance(node, Equation):
-        node_inputs = node.inputs
-    elif isinstance(node, Mox):
-        node_inputs = node.inputs[node.var_tree.num_leaves:]
+def ensure_root_static_kwarg(root: Mox, node: Branch) -> None:
+    args, kwargs = root.in_tree.unflatten(root.inputs)
+    if node.selector_name in kwargs:
+        selector = kwargs[node.selector_name]
+        if not isinstance(selector, Static):
+            raise RuntimeError(
+                f'Root kwarg {node.selector_name!r} already exists and is '
+                'not a Static selector.')
+        set_branch_selector(node, selector)
+        return
+    kwargs[node.selector_name] = node.selector
+    root.inputs, root.in_tree = jax.tree.flatten((args, kwargs))
 
-    if isinstance(repl, Equation):
-        repl_params = []
-        repl_inputs = repl.inputs
-    elif isinstance(repl, Mox):
-        repl_params = repl.inputs[:repl.var_tree.num_leaves]
-        repl_inputs = repl.inputs[repl.var_tree.num_leaves:]
+
+def set_branch_selector(node: Branch, selector: Static) -> None:
+    num_params = node.var_tree.num_leaves
+    old_selector = node.inputs[num_params]
+    node.selector = selector
+    node.inputs[num_params] = selector
+    replace_symbols(node, {old_selector: selector})
+
+
+def rewire_node(node: Expr, repl: Expr):
+    node_inputs = external_inputs(node)
+
+    repl_params = param_symbols(repl)
+    repl_inputs = external_inputs(repl)
     repl_aux_inputs = repl_inputs[len(node_inputs):]
 
     # Check types of output symbols and preserved input symbols.
@@ -1549,26 +1616,32 @@ def rewire_node(node: Expr, repl: Expr):
 
     # If there are some input symbols then we preserve as many input symbols as
     # possible.
-    repl.inputs = repl_params + node_inputs + repl_aux_inputs
-    repl.outputs = node.outputs
+    new_inputs = node_inputs + repl_aux_inputs
+    if isinstance(repl, Branch):
+        mapping = dict(zip(repl_inputs, new_inputs))
+        mapping.update(zip(repl.outputs, node.outputs))
+        replace_symbols(repl, mapping)
+        set_external_inputs(repl, new_inputs)
+        repl.outputs = node.outputs
+    else:
+        repl.inputs = repl_params + new_inputs
+        repl.outputs = node.outputs
 
 
-def update_in_trees(parents: tuple[Mox, ...], ix: int, repl: Mox):
+def update_in_trees(parents: tuple[Expr, ...], ix: int,
+                    repl: Equation | Mox | Branch):
     orig = parents[-1].children[ix]
-    arity = len(orig.inputs)
-    if isinstance(orig, Mox):
-        arity -= orig.var_tree.num_leaves
+    assert isinstance(orig, Expr)
+    arity = len(external_inputs(orig))
 
-    if isinstance(repl, Equation):
-        repl_inputs = repl.inputs
-    elif isinstance(repl, Mox):
-        repl_inputs = repl.inputs[repl.var_tree.num_leaves:]
+    repl_inputs = external_inputs(repl)
     orig_syms, aux_syms = repl_inputs[:arity], repl_inputs[arity:]
-    if orig.inputs[-arity:] != orig_syms:
+    if external_inputs(orig) != orig_syms:
         raise NotImplementedError(
             'Original input symbols must be preserved at the moment.')
 
     for offset, p in enumerate(reversed(parents)):
+        assert isinstance(p, Mox)
         p.entrypoint = None  # Mark as an ephemeral.
 
         # The first input in the root node is a proper param dict, not a
@@ -1589,18 +1662,20 @@ def update_in_trees(parents: tuple[Mox, ...], ix: int, repl: Mox):
             'Weight params symbols are not preserved.'
 
 
-def update_var_trees(parents: tuple[Mox, ...], ix: int, repl: Mox):
+def update_var_trees(parents: tuple[Expr, ...], ix: int,
+                     repl: Equation | Mox | Branch):
     # Only module expressions have param tree.
-    if not isinstance(repl, Mox):
+    if not param_count(repl):
         return
 
     orig = parents[-1].children[ix]
     orig_name = orig.params.get('name')
     for p in reversed(parents[1:]):
+        assert isinstance(p, Mox)
         # Restore child tree.
-        num_params = repl.var_tree.num_leaves
+        num_params = param_count(repl)
         repl_vars = repl.var_tree.unflatten(repl.inputs[:num_params])
-        repl_name = repl.params.get('name') or f'{repl.module_ty.__name__}_0'
+        repl_name = expr_name(repl)
 
         # Restore parent tree.
         num_params = p.var_tree.num_leaves
@@ -1637,21 +1712,27 @@ def update_var_trees(parents: tuple[Mox, ...], ix: int, repl: Mox):
         repl = p
 
     # Restore child var-tree.
-    num_params = repl.var_tree.num_leaves
+    num_params = param_count(repl)
     repl_vars = repl.var_tree.unflatten(repl.inputs[:num_params])
-    repl_name = repl.params.get('name') or f'{repl.module_ty.__name__}_0'
+    repl_name = expr_name(repl)
 
     # Restore root in-tree.
     root = parents[0]
+    assert isinstance(root, Mox)
     (variables, *inputs), kwargs = root.in_tree.unflatten(root.inputs)
 
     # Update in-place root params.
     if 'params' not in variables:
         variables['params'] = {}
     variables['params'].pop(orig_name, None)
-    assert repl_name not in variables['params'], \
-        'Duplicated key in variables: fix name generation or fix a tree.'
-    variables['params'].update(repl_vars['params'])
+    if isinstance(repl, Branch):
+        assert repl_name not in variables['params'], \
+            'Duplicated key in variables: fix name generation or fix a tree.'
+        variables['params'][repl_name] = repl_vars.get('params', {})
+    else:
+        assert repl_name not in variables['params'], \
+            'Duplicated key in variables: fix name generation or fix a tree.'
+        variables['params'].update(repl_vars['params'])
     args = (variables, *inputs)
     root.inputs, root.in_tree = jax.tree.flatten((args, kwargs))
 

--- a/yax.py
+++ b/yax.py
@@ -291,6 +291,9 @@ class Expr:
     outputs: list[Symbol]
     params: dict[str, Any]
 
+    def to_dict(self) -> dict[str, Any]:
+        raise NotImplementedError
+
 
 @dataclass(slots=True)
 class Equation(Expr):
@@ -365,13 +368,7 @@ class Mox(Expr):
         if recursively:
             children = []
             for child in self.children:
-                if isinstance(child, Mox):
-                    children.append(child.to_dict())
-                elif isinstance(child, Equation):
-                    children.append({
-                        **child.params, 'primitive':
-                        child.prim.name
-                    })
+                children.append(child.to_dict())
             res['children'] = children
         return res
 
@@ -879,18 +876,28 @@ def dump(node: Expr, fileobj: IO[str], *, depth=0):
                 attrs = ''
             print(f'{indent}mod {name} : {name_ty}({attrs}) {{ # {depth}',
                   file=fileobj)
+            for child in node.children:
+                dump(child, fileobj, depth=depth + 1)
+            print(f'{indent}}}', file=fileobj)
+        case Branch():
+            keys = ', '.join(repr(k) for k in node.cases)
+            print(f'{indent}inputs ={node.inputs}', file=fileobj)
+            print(f'{indent}outputs={node.outputs}', file=fileobj)
+            print(f'{indent}branch {node.params.get("name")} : '
+                  f'static_branch(selector={node.selector_name}, '
+                  f'cases=({keys})) {{ # {depth}', file=fileobj)
+            for key, case in node.cases.items():
+                print(f'{indent}  case {key!r} {{', file=fileobj)
+                dump(case, fileobj, depth=depth + 2)
+                print(f'{indent}  }}', file=fileobj)
+            print(f'{indent}}}', file=fileobj)
+        case Equation():
+            print(f'{indent}eq {node.prim.name}', file=fileobj)
+            print(f'{indent}inputs ={node.inputs}', file=fileobj)
+            print(f'{indent}outputs={node.outputs}', file=fileobj)
+            print(f'{indent}{node}', file=fileobj)
         case Expr():
             raise RuntimeError('Unexpected node of type {type(node)}.')
-    for child in node.children:
-        match child:
-            case Mox():
-                dump(child, fileobj, depth=depth + 1)
-            case Equation():
-                print(f'{indent}  eq {child.prim.name}', file=fileobj)
-                print(f'{indent}  inputs ={child.inputs}', file=fileobj)
-                print(f'{indent}  outputs={child.outputs}', file=fileobj)
-                print(f'{indent}  {child}', file=fileobj)
-    print(f'{indent}}}', file=fileobj)
 
 
 def dump_yson(expr: Expr, fileobj: IO[bytes], indent: int = 2):
@@ -928,6 +935,14 @@ def dump_yson(expr: Expr, fileobj: IO[bytes], indent: int = 2):
             if expr.module_ty:
                 root.attributes['type'] = expr.module_ty.__name__
             root.extend(to_yson(child) for child in expr.children)
+        elif isinstance(expr, Branch):
+            root = YsonList([])
+            root.attributes['primitive'] = 'static_branch'
+            root.attributes['selector'] = expr.selector_name
+            for key, case in expr.cases.items():
+                child = to_yson(case)
+                child.attributes['case'] = fmt(key)
+                root.append(child)
         elif isinstance(expr, Equation):
             root = YsonEntity()
             root.attributes['primitive'] = expr.prim.name
@@ -963,14 +978,21 @@ def dump_xml(expr: Expr, fileobj: IO[str], indent: int = 2):
         else:
             return str(val)
 
-    def build_subtree(parent: Element, node: Expr):
+    def build_subtree(parent: Element, node: Expr,
+                      case: BranchKey | None = None):
         attrs = {}
         if isinstance(node, Mox):
             tag = 'module_call'
-            attrs['type'] = node.module_ty.__name__
+            if node.module_ty:
+                attrs['type'] = node.module_ty.__name__
             attrs['ephemeral'] = fmt(node.is_ephemeral)
+        elif isinstance(node, Branch):
+            tag = 'static_branch'
+            attrs['selector'] = node.selector_name
         elif isinstance(node, Equation):
             tag = node.prim.name
+        if case is not None:
+            attrs['case'] = fmt(case)
         attrs.update({
             k: fmt(v)
             for k, v in node.params.items() if v is not None
@@ -979,11 +1001,19 @@ def dump_xml(expr: Expr, fileobj: IO[str], indent: int = 2):
         if isinstance(node, Mox):
             for child in node.children:
                 build_subtree(elem, child)
+        elif isinstance(node, Branch):
+            for key, child in node.cases.items():
+                build_subtree(elem, child, key)
 
     if isinstance(expr, Mox):
         root = Element('module_call', attrib={'ephemeral': 'true'})
         for child in expr.children:
             build_subtree(root, child)
+    elif isinstance(expr, Branch):
+        root = Element('static_branch',
+                       attrib={'selector': expr.selector_name})
+        for key, child in expr.cases.items():
+            build_subtree(root, child, key)
     elif isinstance(expr, Equation):
         root = Element(expr.prim.name, attrib={})
     else:

--- a/yax.py
+++ b/yax.py
@@ -23,8 +23,8 @@ from functools import partial, wraps
 from io import StringIO
 from json import dumps
 from typing import (
-    IO, Any, ClassVar, Generic, ParamSpec, Self, Sequence, Type, TypeAlias,
-    TypeVar)
+    IO, Any, ClassVar, Generic, Mapping, ParamSpec, Self, Sequence, Type,
+    TypeAlias, TypeVar)
 from xml.etree.ElementTree import (
     Element, ElementTree, SubElement, indent as indent_etree)
 
@@ -48,8 +48,9 @@ try:
 except ImportError:
     from jax.tree_util import PyTreeDef
 
-__all__ = ('Equation', 'Expr', 'Literal', 'Mox', 'Symbol', 'Var', 'dump_yson',
-           'dump_xml', 'eval_mox', 'make_mox', 'map_mox', 'query', 'sub')
+__all__ = ('Branch', 'Equation', 'Expr', 'Literal', 'Mox', 'Static',
+           'Symbol', 'Var', 'branch', 'dump_yson', 'dump_xml', 'eval_mox',
+           'make_mox', 'map_mox', 'query', 'sub')
 
 # TODO(@daskol): Python 3.12 introduced new type parameter syntax (PEP-0695)
 # but some code quality tools (e.g. yapf) do not support this syntax.
@@ -255,12 +256,27 @@ class Literal(Symbol[Any]):
         return self.value
 
 
+@dataclass(slots=True, eq=False)
+class Static(Symbol[str]):
+    """A named Python-static input selected at evaluation time."""
+
+    @property
+    def name(self) -> str:
+        return self.value
+
+
 # Check hashability of Symbol hierarchy.
 _ = {
+    Static('kwarg'),
     Symbol(ShapedArray((), jnp.float32)),
     Var(ShapedArray((), jnp.float32)),
     Literal(jnp.empty(()), ShapedArray((), jnp.float32)),
 }
+
+
+def default_treedef(default=()) -> PyTreeDef:
+    _, treedef = jax.tree.flatten(default)
+    return treedef
 
 
 @dataclass(slots=True)
@@ -284,9 +300,31 @@ class Equation(Expr):
         return {**self.params, 'primitive': self.prim.name}
 
 
-def default_treedef(default=()) -> PyTreeDef:
-    _, treedef = jax.tree.flatten(default)
-    return treedef
+BranchKey: TypeAlias = str | bool
+
+
+@dataclass(slots=True)
+class Branch(Expr):
+    """Static branching expression."""
+
+    selector_name: str
+    selector: Static
+    cases: dict[BranchKey, Expr]
+    var_tree: PyTreeDef = field(default_factory=default_treedef)
+
+    def to_dict(self, recursively=True) -> dict[str, Any]:
+        res = {
+            **self.params,
+            'primitive': 'static_branch',
+            'selector': self.selector_name,
+            'cases': tuple(self.cases.keys()),
+        }
+        if recursively:
+            res['children'] = {
+                key: val.to_dict() if hasattr(val, 'to_dict') else {}
+                for key, val in self.cases.items()
+            }
+        return res
 
 
 @dataclass(slots=True)
@@ -340,6 +378,155 @@ class Mox(Expr):
             return getattr(obj, '__name__', str(obj))
         return dumps(self.to_dict(), ensure_ascii=False, indent=indent,
                      default=default)
+
+
+def param_count(expr: Expr) -> int:
+    if isinstance(expr, Mox | Branch):
+        return expr.var_tree.num_leaves
+    return 0
+
+
+def external_inputs(expr: Expr) -> list[Symbol]:
+    num_params = param_count(expr)
+    if isinstance(expr, Branch):
+        return expr.inputs[num_params + 1:]
+    return expr.inputs[num_params:]
+
+
+def set_external_inputs(expr: Expr, inputs: Sequence[Symbol]) -> None:
+    num_params = param_count(expr)
+    if isinstance(expr, Branch):
+        expr.inputs = expr.inputs[:num_params + 1] + [*inputs]
+    else:
+        expr.inputs = expr.inputs[:num_params] + [*inputs]
+
+
+def clone_symbol(sym: Symbol) -> Symbol:
+    if isinstance(sym, Static):
+        return Static(sym.value)
+    if isinstance(sym, Literal):
+        return Literal(sym.value, sym.aval)
+    if isinstance(sym, Var):
+        return Var(sym.value)
+    return Symbol(sym.value)
+
+
+def clone_expr(expr: Expr, memo: dict[Symbol, Symbol] | None = None) -> Expr:
+    if memo is None:
+        memo = {}
+
+    def clone(sym: Symbol) -> Symbol:
+        if sym not in memo:
+            memo[sym] = clone_symbol(sym)
+        return memo[sym]
+
+    obj = copy(expr)
+    obj.inputs = [clone(s) for s in expr.inputs]
+    obj.outputs = [clone(s) for s in expr.outputs]
+    obj.params = {**expr.params}
+    if isinstance(expr, Mox):
+        obj.children = [clone_expr(child, memo) for child in expr.children]
+        obj.rngs = {
+            name: LazyRng(clone(rng.rng), rng.suffix)
+            for name, rng in expr.rngs.items()
+        }
+    elif isinstance(expr, Branch):
+        obj.selector = clone(expr.selector)
+        obj.cases = {
+            key: clone_expr(case, memo)
+            for key, case in expr.cases.items()
+        }
+    return obj
+
+
+def replace_symbols(expr: Expr, mapping: Mapping[Symbol, Symbol]) -> None:
+    def replace(sym: Symbol) -> Symbol:
+        return mapping.get(sym, sym)
+
+    expr.inputs = [replace(s) for s in expr.inputs]
+    expr.outputs = [replace(s) for s in expr.outputs]
+    if isinstance(expr, Mox):
+        expr.children = [child for child in expr.children]
+        expr.rngs = {
+            name: LazyRng(replace(rng.rng), rng.suffix)
+            for name, rng in expr.rngs.items()
+        }
+        for child in expr.children:
+            replace_symbols(child, mapping)
+    elif isinstance(expr, Branch):
+        expr.selector = replace(expr.selector)
+        for case in expr.cases.values():
+            replace_symbols(case, mapping)
+
+
+def normalize_branch_key(key: Any, *, selector_name='selector') -> BranchKey:
+    if isinstance(key, np.bool_):
+        return bool(key)
+    if isinstance(key, bool):
+        return key
+    if isinstance(key, str):
+        return key
+    if isinstance(key, Tracer) or hasattr(key, 'aval'):
+        raise TypeError(
+            f'Static branch selector {selector_name!r} must be a Python '
+            f'str or bool, not {type(key).__name__}.')
+    raise TypeError(
+        f'Unsupported static branch key {key!r} of type {type(key).__name__}.')
+
+
+def merge_branch_params(cases: Mapping[BranchKey, Expr]) \
+        -> tuple[list[Symbol], PyTreeDef, dict[Symbol, Symbol]]:
+    """Merge case parameter symbols by variable path and symbol identity."""
+    raise NotImplementedError
+
+
+def branch(selector_name: str,
+           cases: Mapping[str | bool | np.bool_, Expr],
+           *, name: str | None = None) -> Branch:
+    """Build a static branch expression selected by a named kwarg."""
+    if not isinstance(selector_name, str) or not selector_name:
+        raise ValueError('Branch selector name must be a non-empty string.')
+    if not cases:
+        raise ValueError('Static branch requires at least one case.')
+
+    normalized: dict[BranchKey, Expr] = {}
+    for key, expr in cases.items():
+        norm_key = normalize_branch_key(key, selector_name=selector_name)
+        if norm_key in normalized:
+            raise ValueError(f'Duplicate static branch key {norm_key!r}.')
+        if not isinstance(expr, Expr):
+            raise TypeError(
+                f'Branch case {norm_key!r} must be an {type(Expr).__name__}, '
+                f'not {type(expr).__name__}.')
+        normalized[norm_key] = clone_expr(expr)
+
+    first_case = next(iter(normalized.values()))
+    first_inputs = [*external_inputs(first_case)]
+    first_outputs = [*first_case.outputs]
+    for key, case in tuple(normalized.items())[1:]:
+        validate_symbols(first_inputs, external_inputs(case),
+                         f'case {key!r} input')
+        validate_symbols(first_outputs, case.outputs, f'case {key!r} output')
+
+    params, var_tree, param_mapping = merge_branch_params(normalized)
+    for case in normalized.values():
+        replace_symbols(case, param_mapping)
+
+    # Recompute after parameter rewrites in case a boundary intentionally
+    # aliases a parameter symbol.
+    first_inputs = [*external_inputs(first_case)]
+    first_outputs = [*first_case.outputs]
+    for case in tuple(normalized.values())[1:]:
+        input_mapping = dict(zip(external_inputs(case), first_inputs))
+        output_mapping = dict(zip(case.outputs, first_outputs))
+        replace_symbols(case, input_mapping | output_mapping)
+        set_external_inputs(case, first_inputs)
+        case.outputs = first_outputs
+
+    selector = Static(selector_name)
+    return Branch(params + [selector] + first_inputs, first_outputs,
+                  {'name': name}, selector_name, selector, normalized,
+                  var_tree)
 
 
 def make_mox(fn: Callable[Args, Any]) -> Callable[Args, Mox]:

--- a/yax.py
+++ b/yax.py
@@ -1355,6 +1355,36 @@ def eval_equation(read, write, eq: Equation):
         write(sym, val)
 
 
+def eval_branch(read, write, node: Branch):
+    try:
+        selector = read(node.selector)
+    except KeyError as e:
+        raise KeyError(
+            f'Missing static branch selector {node.selector_name!r}.') from e
+    key = normalize_branch_key(selector, selector_name=node.selector_name)
+    if key not in node.cases:
+        available = ', '.join(repr(k) for k in node.cases)
+        raise ValueError(
+            f'Unsupported value {selector!r} for static branch selector '
+            f'{node.selector_name!r}; available cases are: {available}.')
+    eval_expr(read, write, node.cases[key])
+
+
+def eval_expr(read, write, node: Expr):
+    if isinstance(node, Mox):
+        if node.is_ephemeral:
+            for child in node.children:
+                eval_expr(read, write, child)
+        else:
+            eval_module(read, write, node)
+    elif isinstance(node, Branch):
+        eval_branch(read, write, node)
+    elif isinstance(node, Equation):
+        eval_equation(read, write, node)
+    else:
+        raise RuntimeError(f'Unexpected expression type {type(node)}.')
+
+
 def eval_mox(tree: Mox, *args, **kwargs):
     """Evaluate a module expression `tree` with `args` and `kwargs`."""
     env: dict[Symbol, Any] = {}
@@ -1371,21 +1401,18 @@ def eval_mox(tree: Mox, *args, **kwargs):
         assert var not in env, f'Variable {var} has been already defined.'
         env[var] = val
 
-    def fn(node: Expr) -> Mox | None:
-        if isinstance(node, Mox):
-            if node.is_ephemeral:
-                return node
-            else:
-                return eval_module(read, write, node)
-        elif isinstance(node, Equation):
-            return eval_equation(read, write, node)
+    # Verify presence of necessary static arguments.
+    for node in query('//static_branch', tree):
+        if isinstance(node, Branch) and node.selector_name not in kwargs:
+            raise KeyError(
+                f'Missing static branch selector {node.selector_name!r}.')
 
     # Initialize execution context and execute.
     flat_args, in_tree = jax.tree.flatten((args, kwargs))
     assert in_tree == tree.in_tree, \
         f'Arguments and input tree mismatched: {in_tree} vs {tree.in_tree}.'
     jax.tree.map(write, tree.inputs, flat_args)
-    map_mox(fn, tree)
+    eval_expr(read, write, tree)
 
     flatten_res = [read(x) for x in tree.outputs]
     if len(flatten_res) == 1:

--- a/yax.py
+++ b/yax.py
@@ -407,6 +407,8 @@ def external_params(expr: Expr) -> list[Symbol]:
 def external_param_tree(expr: Expr) -> ArrayTree:
     leaves = external_params(expr)
     match expr:
+        case Equation():
+            return {}
         case Mox():
             node = cast(Mox, expr)
         case Branch():
@@ -414,8 +416,7 @@ def external_param_tree(expr: Expr) -> ArrayTree:
         case _:
             raise RuntimeError(
                 f'No treedef for an object of type {type(expr).__name__}.')
-    params = jax.tree.unflatten(node.var_tree, params)
-    return params
+    return jax.tree.unflatten(node.var_tree, leaves)
 
 
 def set_external_inputs(expr: Expr, inputs: Sequence[Symbol]) -> None:
@@ -511,7 +512,7 @@ def unwrap_key_path(kp: KeyPath) -> tuple[str, ]:
             case DictKey():
                 parts.append(part.key)
             case SequenceKey():
-                parts.append(part.id)
+                parts.append(part.idx)
             case _:
                 raise RuntimeError(
                     f'Unexpected type of key part: {type(part)}.')
@@ -551,7 +552,8 @@ def reconstruct(flat_dict: Mapping[Key, Any]):
     >>> reconstruct({(0, 'a'): 1, (0, 'b'): 2, (1, 'a'): 3})
     [{'a': 1, 'b': 2}, {'a': 3}]
     """
-
+    if flat_dict == {}:
+        return {}
     if () in flat_dict and len(flat_dict) == 1:
         return flat_dict[()]  # Leaf.
     elif () in flat_dict:
@@ -600,8 +602,46 @@ def map_param_tree(fn: Callable[[Sequence[ArrayTree | None]], Any],
 
 def merge_branch_params(cases: Mapping[BranchKey, Expr]) \
         -> tuple[list[Symbol], PyTreeDef, dict[Symbol, Symbol]]:
-    """Merge case parameter symbols by variable path and symbol identity."""
-    raise NotImplementedError
+    """Merge case parameter symbols by variable path and symbol identity.
+
+    1. Restore param tree.
+    2. Symbols at the same paths are the same symbols.
+    3. Merge variable trees.
+       {/a: s1} + {/a: s2} -> {/a: Sa}
+       {/a: s1} + {/b: s2} -> {/a: Sa, /b: Sb}
+       {/a: s1, /b: s1} + {/a: s2, /c: s2} -> error: s1 at both /a and /b
+    """
+    param_trees = []
+    for _, expr in cases.items():
+        param_tree = external_param_tree(expr)
+        param_trees += [param_tree]
+
+    def fn(leaves: Sequence[ArrayTree | None]) -> ArrayTree:
+        symbols: Sequence[Symbol] = [x for x in leaves if x is not None]
+        if len(symbols) == 0:
+            raise RuntimeError(f'No array tree defined: {leaves}.')
+        symbol, *symbols = symbols
+        return symbol
+
+    # Build union tree of parameter trees.
+    params = map_param_tree(fn, param_trees)
+    leaves, treedef = jax.tree.flatten(params)
+
+    # Build mapping between shared symbols and branch arm symbols.
+    mapping: dict[Symbol, Symbol] = {}
+    flat_params, *_ = to_flat_dict(params)
+    for param_tree in param_trees:
+        flat_param_tree, *_ = to_flat_dict(param_tree)
+        for key, sym in flat_param_tree.items():
+            if (shared_sym := flat_params[key]) == sym:
+                continue
+            mapping[sym] = shared_sym
+
+    # Then replace branch symbols with shared ones.
+    for _, expr in cases.items():
+        replace_symbols(expr, mapping)
+
+    return leaves, treedef, mapping
 
 
 def branch(selector_name: str,


### PR DESCRIPTION
This PR allows to express a static dependencies on an input argument that affects traced computations (it should not be confused with `jax.lax.cond` or `jax.lax.switch`).